### PR TITLE
Jerk-limited trajectoy generator improvements

### DIFF
--- a/trajectory_generator/VelocitySmoothing.py
+++ b/trajectory_generator/VelocitySmoothing.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+File: VelocitySmoothing.py
+Author: Mathieu Bresciani
+Email: brescianimathieu@gmail.com
+Github: https://github.com/bresch
+Description:
+    Given a desired velocity setpoint v_d, the trajectory generator computes
+    a time-optimal trajectory satisfaying the following variable constraints:
+    - j_max : maximum jerk
+    - a_max : maximum acceleration
+    - v_max : maximum velocity
+    - a0 : initial acceleration
+    - v0 : initial velocity
+    - v3 : final velocity
+    The hard constraint used to generate the optimizer is:
+    - a3 = 0.0 : final acceleration
+
+    The trajectory generated is made by three parts:
+    1) Increasing acceleration during T1 seconds
+    2) Constant acceleration during T2 seconds
+    3) Decreasing acceleration during T3 seconds
+"""
+
+from numpy import *
+import sys
+import math
+import matplotlib.pylab as plt
+
+FLT_EPSILON = sys.float_info.epsilon
+NAN = float('nan')
+verbose = True;
+
+if verbose:
+    def verboseprint(*args):
+        # Print each argument separately so caller doesn't need to
+        # stuff everything to be printed into a single string
+        for arg in args:
+           print arg,
+        print
+else:
+    verboseprint = lambda *a: None      # do-nothing function
+
+class VelocitySmoothing(object):
+
+    def __init__(self, a0, v0, x0):
+        self._jerk = 0.0
+        self._accel = a0
+        self._vel = v0
+        self._pos = x0
+        self._dt = 0.1
+        self._vel_sp = 0.0
+
+        self._max_jerk = 9.0
+        self._max_accel = 3.0
+        self._max_vel = 5.0
+
+        self._jerk_max_T3 = 0.0
+
+        self._T1 = 0.0
+        self._T2 = 0.0
+        self._T3 = 0.0
+
+    def computeT1(self, a0, v3, j_max, a_max, dt):
+        delta = 2.0*a0**2 + 4.0*j_max*v3
+
+        if delta < 0.0:
+            verboseprint('Complex roots\n')
+            return (0.0, True);
+
+        T1_plus = (-a0 + 0.5*sqrt(delta))/j_max
+        T1_minus = (-a0 - 0.5*sqrt(delta))/j_max
+
+        verboseprint('T1_plus = {}, T1_minus = {}'.format(T1_plus, T1_minus))
+        # Use the solution that produces T1 >= 0 and T3 >= 0
+        T3_plus = a0/j_max + T1_plus
+        T3_minus = a0/j_max + T1_minus
+
+        if T1_plus >= 0.0 and T3_plus >= 0.0:
+            T1 = T1_plus
+        elif T1_minus >= 0.0 and T3_minus >= 0.0:
+            T1 = T1_minus
+        else:
+            verboseprint("Warning")
+            T1 = 0.0
+
+        if T1 < dt or T1 < 0.0:
+            T1 = 0.0
+
+        (T1, trapezoidal) = self.saturateT1ForAccel(a0, j_max, T1)
+
+        return (T1, trapezoidal)
+
+    def saturateT1ForAccel(self, a0, j_max, T1):
+        trapezoidal = True
+        # Check maximum acceleration, saturate and recompute T1 if needed
+        a1 = a0 + j_max*T1
+        if a1 > a_max:
+            T1 = (a_max - a0) / j_max
+            trapezoidal = True
+        elif a1 < -a_max:
+            T1 = (-a_max - a0) / j_max
+            trapezoidal = True
+
+        return (T1, trapezoidal)
+
+    def computeT3(self, T1, a0, j_max, dt):
+        T3 = a0/j_max + T1
+        j_max_T3 = j_max
+
+        if T1 < FLT_EPSILON and T3 < dt and T3 > FLT_EPSILON:
+            # Force T3 to be the size of dt
+            T3 = dt
+
+            # Adjust new max jerk for adjusted T3
+            # such that the acceleration can go from a0
+            # to 0 in a single step (T3 = dt)
+            j_max_T3 = a0/T3
+
+        return (T3, j_max_T3)
+
+    def computeT2(self, T1, T3, a0, v3, j_max):
+        T2 = 0.0
+
+        den = T1*j_max + a0
+        if abs(den) > FLT_EPSILON:
+            T2 = (-0.5*T1**2*j_max - T1*T3*j_max - T1*a0 + 0.5*T3**2*j_max - T3*a0 + v3)/den
+
+        return T2
+
+    def integrateT(self, dt, j, a_prev, v_prev, x_prev):
+        a_T = j * dt + a_prev
+        #v_T = j*dt*dt/2.0 + a_prev*dt + v_prev # Original equation: 3 mult + 1 div + 2 add
+        v_T = dt/2.0 * (a_T + a_prev) + v_prev # Simplification using a_T: 1 mult + 1 div + 2 add
+        #x_T = j*dt*dt*dt/6.0 + a_prev*dt*dt/2.0 + v_prev*dt + x_prev # Original equation: 6 mult + 2 div + 3 add
+        x_T = dt/3.0 * (v_T + a_prev*dt/2.0 + 2*v_prev) + x_prev # Simplification using v_T: 3 mult + 2 div + 3 add
+
+        return (a_T, v_T, x_T)
+
+    def updateDurations(self):
+        # Depending of the direction, start accelerating positively or negatively
+        # For this, we need to predict what would be the velocity at zero acceleration
+        # because it could be that the current acceleration is too high and that we need
+        # to start reducing the acceleration directly even if sign(v_d - v_T) < 0
+        if abs(self._accel) > FLT_EPSILON:
+            j_zero_acc = -sign(self._accel) * abs(self._max_jerk);
+            t_zero_acc = -self._accel / j_zero_acc;
+            vel_zero_acc = self._vel + self._accel * t_zero_acc + 0.5 * j_zero_acc * t_zero_acc * t_zero_acc;
+            verboseprint("vel_zero_acc = {}\tt_zero_acc = {}".format(vel_zero_acc, t_zero_acc))
+            verboseprint("vel = {}, accel = {}, jerk = {}".format(self._vel, self._accel, j_zero_acc))
+        else:
+            vel_zero_acc = self._vel
+
+        if self._vel_sp > vel_zero_acc:
+            jerk = abs(self._max_jerk)
+        else:
+            jerk = -abs(self._max_jerk)
+
+        delta_v = self._vel_sp - self._vel
+        # Compute increasing acceleration time
+        (T1, trapezoidal) = self.computeT1(self._accel, delta_v, jerk, self._max_accel, self._dt)
+        # Compute decreasing acceleration time
+	(T3, max_jerk_T3) = self.computeT3(T1, self._accel, jerk, self._dt);
+        # Compute constant acceleration time
+        if trapezoidal:
+            T2 = self.computeT2(T1, T3, self._accel, delta_v, max_jerk_T3)
+            if T2 < self._dt:
+                verboseprint("T2 < dt: {}".format(T2))
+                T2 = 0.0
+        else:
+            T2 = 0.0
+
+        self._T1 = T1
+        self._T2 = T2
+        self._T3 = T3
+        self._max_jerk_T3 = max_jerk_T3
+
+    def update(self, dt, vel_sp):
+        self._dt = dt
+        self._vel_sp = clip(vel_sp, -self._max_vel, self._max_vel)
+        self.updateDurations()
+
+    def integrate(self):
+        if self._T1 > FLT_EPSILON:
+            self._jerk = self._max_jerk_T3
+        elif self._T2 > FLT_EPSILON:
+            self._jerk = 0.0
+        elif self._T3 > FLT_EPSILON:
+            self._jerk = -self._max_jerk_T3
+        else:
+            self._jerk = 0.0
+
+        # Integrate trajectory
+        (self._accel, self._vel, self._pos) = self.integrateT(self._dt, self._jerk, self._accel, self._vel, self._pos)
+
+        return (self._accel, self._vel, self._pos)
+
+if __name__ == '__main__':
+    # Initial conditions
+    a0 = 3.0
+    v0 = 0.1
+    x0 = 0.0
+
+    # Constraints
+    j_max = 15.0
+    a_max = 5.31
+    v_max = 12.0
+
+    # Simulation time parameters
+    dt_0 = 0.014789
+    t_end = 2.40
+
+    # Initialize vectors
+    t = arange (0.0, t_end+dt_0, dt_0)
+    n = len(t)
+
+    j_T = zeros(n)
+    j_T_corrected = zeros(n)
+    a_T = zeros(n)
+    v_T = zeros(n)
+    x_T = zeros(n)
+    v_d = zeros(n)
+
+    j_T[0] = 0.0
+    j_T_corrected[0] = 0.0
+    a_T[0] = a0
+    v_T[0] = v0
+    x_T[0] = x0
+    v_d[0] = 0.398
+
+    traj = VelocitySmoothing(a0, v0, x0)
+    traj._max_jerk = j_max
+    traj._max_accel = a_max
+    traj._max_vel = v_max
+    traj._dt = dt_0
+
+    # Main loop
+    for k in range(0, n):
+        verboseprint('k = {}\tt = {}'.format(k, t[k]))
+        (a_T[k], v_T[k], x_T[k]) = traj.integrate()
+        traj.update(dt_0, v_d[k])
+        verboseprint("T1 = {}\tT2 = {}\tT3 = {}\n".format(traj._T1, traj._T2, traj._T3))
+        j_T[k] = traj._jerk
+
+    plt.plot(t, v_d)
+    plt.plot(t, j_T, '*')
+    plt.plot(t, a_T, '*')
+    plt.plot(t, v_T)
+    plt.plot(t, x_T)
+    plt.plot(arange (0.0, t_end+dt_0, dt_0), t)
+    plt.plot(t, j_T_corrected)
+    plt.legend(["v_d", "j_T", "a_T", "v_T", "x_T", "t"])
+    plt.xlabel("time (s)")
+    plt.ylabel("metric amplitude")
+    plt.show()

--- a/trajectory_generator/VelocitySmoothing.py
+++ b/trajectory_generator/VelocitySmoothing.py
@@ -145,6 +145,8 @@ class VelocitySmoothing(object):
         return (a_T, v_T, x_T)
 
     def updateDurations(self):
+        if (abs(self._accel) > self._max_accel):
+            verboseprint("Should be double deceleration profile!")
         # Depending of the direction, start accelerating positively or negatively
         # For this, we need to predict what would be the velocity at zero acceleration
         # because it could be that the current acceleration is too high and that we need
@@ -217,7 +219,7 @@ class VelocitySmoothing(object):
 
 if __name__ == '__main__':
     # Initial conditions
-    a0 = 3.0
+    a0 = -8.0
     v0 = 12.0
     x0 = 0.0
 

--- a/trajectory_generator/VelocitySmoothing.py
+++ b/trajectory_generator/VelocitySmoothing.py
@@ -50,25 +50,24 @@ class VelocitySmoothing(object):
         self._vel = v0
         self._pos = x0
 
-    def __init__(self, dt, a0, v0, x0):
+    def __init__(self, a0, v0, x0):
         self._jerk = 0.0
-        self._accel = a0
-        self._vel = v0
-        self._pos = x0
-        self._dt = dt
+        self._accel = self._at0 = a0
+        self._vel = self._vt0 = v0
+        self._pos = self._xt0 = x0
         self._vel_sp = 0.0
+        self._d = 0
+        self._t0 = 0.0
 
         self._max_jerk = 9.0
         self._max_accel = 3.0
         self._max_vel = 5.0
 
-        self._max_jerk_T3 = 0.0
-
         self._T1 = 0.0
         self._T2 = 0.0
         self._T3 = 0.0
 
-    def computeT1(self, a0, v3, j_max, a_max, dt):
+    def computeT1(self, a0, v3, j_max, a_max):
         delta = 2.0*a0**2 + 4.0*j_max*v3
 
         if delta < 0.0:
@@ -91,15 +90,12 @@ class VelocitySmoothing(object):
             verboseprint("Warning")
             T1 = 0.0
 
-        if T1 < dt or T1 < 0.0:
-            T1 = 0.0
-
         (T1, trapezoidal) = self.saturateT1ForAccel(a0, j_max, T1)
 
         return (T1, trapezoidal)
 
     def saturateT1ForAccel(self, a0, j_max, T1):
-        trapezoidal = True
+        trapezoidal = False
         # Check maximum acceleration, saturate and recompute T1 if needed
         a1 = a0 + j_max*T1
         if a1 > a_max:
@@ -111,20 +107,10 @@ class VelocitySmoothing(object):
 
         return (T1, trapezoidal)
 
-    def computeT3(self, T1, a0, j_max, dt):
+    def computeT3(self, T1, a0, j_max):
         T3 = a0/j_max + T1
-        j_max_T3 = j_max
 
-        if T1 < FLT_EPSILON and T3 < dt and T3 > FLT_EPSILON:
-            # Force T3 to be the size of dt
-            T3 = dt
-
-            # Adjust new max jerk for adjusted T3
-            # such that the acceleration can go from a0
-            # to 0 in a single step (T3 = dt)
-            j_max_T3 = a0/T3
-
-        return (T3, j_max_T3)
+        return T3
 
     def computeT2(self, T1, T3, a0, v3, j_max):
         T2 = 0.0
@@ -135,23 +121,16 @@ class VelocitySmoothing(object):
 
         return T2
 
-    def integrateT(self, dt, j, a_prev, v_prev, x_prev):
-        a_T = j * dt + a_prev
-        #v_T = j*dt*dt/2.0 + a_prev*dt + v_prev # Original equation: 3 mult + 1 div + 2 add
-        v_T = dt/2.0 * (a_T + a_prev) + v_prev # Simplification using a_T: 1 mult + 1 div + 2 add
-        #x_T = j*dt*dt*dt/6.0 + a_prev*dt*dt/2.0 + v_prev*dt + x_prev # Original equation: 6 mult + 2 div + 3 add
-        x_T = dt/3.0 * (v_T + a_prev*dt/2.0 + 2*v_prev) + x_prev # Simplification using v_T: 3 mult + 2 div + 3 add
+    def updateDurations(self, t):
 
-        return (a_T, v_T, x_T)
-
-    def updateDurations(self):
         if (abs(self._accel) > self._max_accel):
             verboseprint("Should be double deceleration profile!")
         # Depending of the direction, start accelerating positively or negatively
         # For this, we need to predict what would be the velocity at zero acceleration
         # because it could be that the current acceleration is too high and that we need
         # to start reducing the acceleration directly even if sign(v_d - v_T) < 0
-        if abs(self._accel) > FLT_EPSILON:
+        do_stop_check = False
+        if abs(self._accel) > FLT_EPSILON and do_stop_check:
             j_zero_acc = -sign(self._accel) * abs(self._max_jerk);
             t_zero_acc = -self._accel / j_zero_acc;
             vel_zero_acc = self._vel + self._accel * t_zero_acc + 0.5 * j_zero_acc * t_zero_acc * t_zero_acc;
@@ -160,134 +139,148 @@ class VelocitySmoothing(object):
         else:
             vel_zero_acc = self._vel
 
-        if self._vel_sp > vel_zero_acc:
-            jerk = abs(self._max_jerk)
-        else:
-            jerk = -abs(self._max_jerk)
+        self._d = sign(self._vel_sp - vel_zero_acc)
+        jerk = self._d*self._max_jerk
+
+        if abs(jerk) < 0.5 * self._max_jerk:
+            self._T1 = self._T2 = self._T3 = 0.0
+            print("Return")
+            return
+
+        self._at0 = self._accel
+        self._vt0 = self._vel
+        self._xt0 = self._pos
 
         delta_v = self._vel_sp - self._vel
         # Compute increasing acceleration time
-        (T1, trapezoidal) = self.computeT1(self._accel, delta_v, jerk, self._max_accel, self._dt)
+        (T1, trapezoidal) = self.computeT1(self._accel, delta_v, jerk, self._max_accel)
         # Compute decreasing acceleration time
-	(T3, max_jerk_T3) = self.computeT3(T1, self._accel, jerk, self._dt);
+	T3 = self.computeT3(T1, self._accel, jerk);
         # Compute constant acceleration time
         if trapezoidal:
-            T2 = self.computeT2(T1, T3, self._accel, delta_v, max_jerk_T3)
-            if T2 < self._dt:
-                verboseprint("T2 < dt: {}".format(T2))
-                T2 = 0.0
+            T2 = self.computeT2(T1, T3, self._accel, delta_v, jerk)
+
         else:
             T2 = 0.0
 
         self._T1 = T1
         self._T2 = T2
         self._T3 = T3
-        self._max_jerk_T3 = max_jerk_T3
+        self._t0 = t
 
-    def update(self, dt, vel_sp):
-        self._dt = dt
+    def update(self, vel_sp, t):
         self._vel_sp = clip(vel_sp, -self._max_vel, self._max_vel)
-        self.updateDurations()
+        self.updateDurations(t)
 
-    def integrate(self, dt):
-        if self._T1 > FLT_EPSILON:
-            self._jerk = self._max_jerk_T3
-        elif self._T2 > FLT_EPSILON:
-            self._jerk = 0.0
-        elif self._T3 > FLT_EPSILON:
-            self._jerk = -self._max_jerk_T3
+    def evaluatePoly(self, j, a0, v0, x0, t, d):
+        jt = d*j
+        at = a0 + jt*t
+        vt = v0 + a0*t + 0.5*jt*t**2
+        xt = x0 + v0*t + 0.5*a0*t**2 + 1.0/6.0*jt*t**3
+
+        return (jt, at, vt, xt)
+
+    def evaluateTraj(self, t_now):
+        """evaluate trajectory for the given time
+        """
+        j = self._max_jerk
+        d = self._d
+        t = t_now - self._t0
+
+        if t <= self._T1:
+            t1 = t
+            (self._jerk, self._accel, self._vel, self._pos) = self.evaluatePoly(j, self._at0, self._vt0, self._xt0, t1, d)
+
+        elif t <= self._T1 + self._T2:
+            t1 = self._T1
+            t2 = t - self._T1
+
+            (self._jerk, self._accel, self._vel, self._pos) = self.evaluatePoly(j, self._at0, self._vt0, self._xt0, t1, d)
+            (self._jerk, self._accel, self._vel, self._pos) = self.evaluatePoly(0.0, self._accel, self._vel, self._pos, t2, 0.0)
+
+        elif t <= self._T1 + self._T2 + self._T3:
+            t1 = self._T1
+            t2 = self._T2
+            t3 = t - self._T1 - self._T2
+
+            (self._jerk, self._accel, self._vel, self._pos) = self.evaluatePoly(j, self._at0, self._vt0, self._xt0, t1, d)
+            (self._jerk, self._accel, self._vel, self._pos) = self.evaluatePoly(0.0, self._accel, self._vel, self._pos, t2, 0.0)
+            (self._jerk, self._accel, self._vel, self._pos) = self.evaluatePoly(j, self._accel, self._vel, self._pos, t3, -d)
+
         else:
-            self._jerk = 0.0
+            # TODO : do not recompute if the sequence has already been completed
+            t1 = self._T1
+            t2 = self._T2
+            t3 = self._T3
 
-        # TODO: check new dt and compensate for jitter
+            (self._jerk, self._accel, self._vel, self._pos) = self.evaluatePoly(j, self._at0, self._vt0, self._xt0, t1, d)
+            (self._jerk, self._accel, self._vel, self._pos) = self.evaluatePoly(0.0, self._accel, self._vel, self._pos, t2, 0.0)
+            (self._jerk, self._accel, self._vel, self._pos) = self.evaluatePoly(j, self._accel, self._vel, self._pos, t3, -d)
+            (self._jerk, self._accel, self._vel, self._pos) = self.evaluatePoly(0.0, 0.0, self._vel_sp, self._pos, t - self._T1 - self._T2 - self._T3, 0.0)
 
-        # Integrate trajectory
-        (self._accel, self._vel, self._pos) = self.integrateT(self._dt, self._jerk, self._accel, self._vel, self._pos)
-
-        return (self._accel, self._vel, self._pos)
-
-    def computeEndPosition(self):
-        j = self._max_jerk_T3
-        T1 = self._T1
-        T2 = self._T2
-        T3 = self._T3
-        xt3 = T1**3*j/6 + 0.5*T1**2*a0 + T1*v0 + T2**2*(0.5*T1*j + 0.5*a0) + T2*(0.5*T1**2*j + T1*a0 + v0) - T3**3*j/6 + T3**2*(0.5*T1*j + 0.5*a0) + T3*(0.5*T1**2*j + T1*a0 + T2*(T1*j + a0) + v0) + x0
-        xt3_simp = T1*v0 + T3*(T1*a0 + T2*a0 + v0) + x0
-
-        return (xt3, xt3_simp)
+        return (self._jerk, self._accel, self._vel, self._pos)
 
 
 if __name__ == '__main__':
     # Initial conditions
-    a0 = -8.0
-    v0 = 12.0
+    a0 = 1.18
+    v0 = 2.52
     x0 = 0.0
 
     # Constraints
-    j_max = 15.0
-    a_max = 5.31
+    j_max = 8.0
+    a_max = 4.0
     v_max = 12.0
 
     # Simulation time parameters
-    dt_0 = 0.014789
-    t_end = 3.0
+    dt_0 = 0.02
+    t_end = 6.0
 
     # Initialize vectors
     t = arange (0.0, t_end+dt_0, dt_0)
     n = len(t)
 
     j_T = zeros(n)
-    j_T_corrected = zeros(n)
     a_T = zeros(n)
     v_T = zeros(n)
     x_T = zeros(n)
     v_d = zeros(n)
 
     j_T[0] = 0.0
-    j_T_corrected[0] = 0.0
     a_T[0] = a0
     v_T[0] = v0
     x_T[0] = x0
-    v_d[0] = 0.0
-    x_d = 30.0
+    v_d[0] = 2.34
 
-    traj = VelocitySmoothing(dt_0, a0, v0, x0)
+    traj = VelocitySmoothing(a0, v0, x0)
     traj._max_jerk = j_max
     traj._max_accel = a_max
     traj._max_vel = v_max
     traj._dt = dt_0
-    braking_distance = VelocitySmoothing(dt_0, a0, v0, x0)
-    braking_distance._max_jerk = j_max
-    braking_distance._max_accel = a_max
-    braking_distance._max_vel = v_max
-    braking_distance._dt = dt_0
-
-    xt3 = 0.0
-    xt3_simp = 0.0
 
     # Main loop
     for k in range(0, n):
+        if k != 0:
+            if t[k] < 1.0:
+                v_d[k] = v_d[k-1]
+            elif t[k] < 1.3:
+                v_d[k] = 1.0
+            elif t[k] < 3.0:
+                v_d[k] = 1.5
+            else:
+                v_d[k] = -3.0
         verboseprint('k = {}\tt = {}'.format(k, t[k]))
-        (a_T[k], v_T[k], x_T[k]) = traj.integrate(dt_0)
-        traj.update(dt_0, v_d[k])
-        if k == 0:
-            # Predict the stop position if we decide to brake now
-            braking_distance.setState(traj._accel, traj._vel, traj._pos)
-            braking_distance.update(dt_0, 0.0)
-            (xt3, xt3_simp) = braking_distance.computeEndPosition()
+        (j_T[k], a_T[k], v_T[k], x_T[k]) = traj.evaluateTraj(t[k])
+        traj.update(v_d[k], t[k])
 
         verboseprint("T1 = {}\tT2 = {}\tT3 = {}\n".format(traj._T1, traj._T2, traj._T3))
-        j_T[k] = traj._jerk
 
-    print("Predicted final position = {} ; simplified: {}".format(xt3, xt3_simp))
     plt.plot(t, v_d)
-    plt.plot(t, j_T, '*')
-    plt.plot(t, a_T, '*')
+    plt.plot(t, j_T)
+    plt.plot(t, a_T)
     plt.plot(t, v_T)
-    plt.plot(t, x_T)
-    plt.plot(arange (0.0, t_end+dt_0, dt_0), t)
-    plt.plot(t, j_T_corrected)
-    plt.legend(["v_d", "j_T", "a_T", "v_T", "x_T", "t"])
+    plt.plot(t, x_T, '--')
+    plt.legend(["v_d", "j_T", "a_T", "v_T", "x_T"])
     plt.xlabel("time (s)")
     plt.ylabel("metric amplitude")
     plt.show()

--- a/trajectory_generator/closed_loop_ziegler_nichols.py
+++ b/trajectory_generator/closed_loop_ziegler_nichols.py
@@ -16,25 +16,32 @@ Description:
 def compute_PID(K_u, T_u, rule="classical"):
     if rule == "classical":
         K_p = 0.6*K_u
-        K_i = 2.0*K_p/T_u
-        K_d = K_p*T_u/8.0
+        T_i = 0.5*T_u
+        T_d = T_u/8.0
 
     elif rule == "overshoot":
         K_p = 0.33*K_u
-        K_i = 2.0*K_p/T_u
-        K_d = K_p*T_u/3.0
+        T_i = 0.5*T_u
+        T_d = T_u/3.0
 
     elif rule == "no_overshoot":
         K_p = 0.2*K_u
-        K_i = 2.0*K_p/T_u
-        K_d = K_p*T_u/3.0
+        T_i = 0.5*T_u
+        T_d = T_u/3.0
 
     elif rule == "pessen":
         K_p = 0.7*K_u
-        K_i = 2.5*K_p/T_u
-        K_d = 0.15*K_p*T_u
+        T_i = 0.4*T_u
+        T_d = 0.15*T_u
 
-    return (K_p, K_i, K_d)
+    return (K_p, T_i, T_d)
+
+def non_interacting_to_parallel(Kp_n, Ti_n, Td_n):
+    Kp_p = Kp_n
+    Ki_p = Kp_n / Ti_n
+    Kd_p = Kp_n * Td_n
+
+    return (Kp_p, Ki_p, Kd_p)
 
 def compute_ARW_gain(K_p, K_i, K_d):
     K_ARW = 2.0 / K_p
@@ -47,7 +54,8 @@ T_u = 0.5 # Oscillation period in seconds at critical gain
 rules = ["classical", "overshoot", "no_overshoot", "pessen"]
 
 for rule in rules:
-
-    (K_p, K_i, K_d) = compute_PID(K_u, T_u, rule=rule)
-    K_ARW = compute_ARW_gain(K_p, K_i, K_d)
-    print("Rule \"{}\"\nKp = {}\nKi = {}\nKd = {}\nK_ARW = {}".format(rule, K_p, K_i, K_d, K_ARW))
+    (Kp_i, Ti_i, Td_i) = compute_PID(K_u, T_u, rule=rule)
+    (Kp_p, Ki_p, Kd_p) = non_interacting_to_parallel(Kp_i, Ti_i, Td_i)
+    K_ARW = compute_ARW_gain(Kp_p, Ki_p, Kd_p)
+    print("Rule \"{}\"\nParallel:\nKp = {}\tKi = {}\tKd = {}\tK_ARW = {}".format(rule, Kp_p, Ki_p, Kd_p, K_ARW))
+    print("Non-Interacting:\nKp = {}\tTi = {}\tTd = {}\n".format(Kp_i, Ti_i, Td_i))

--- a/trajectory_generator/velocity_trajectory_generator.py
+++ b/trajectory_generator/velocity_trajectory_generator.py
@@ -291,7 +291,19 @@ for k in range(0, n):
         v_d[k] = 5.0
 
     # Depending of the direction, start accelerating positively or negatively
-    if sign(v_d[k]-v_T[k]) > 0:
+    # For this, we need to predict what would be the velocity at zero acceleration
+    # because it could be that the current acceleration is too high and that we need
+    # to start reducing the acceleration directly even if sign(v_d - v_T) < 0
+    if abs(a_T[k]) > FLT_EPSILON:
+        j_zero_acc = -sign(a_T[k]) * abs(j_max);
+        t_zero_acc = -a_T[k] / j_zero_acc;
+        vel_zero_acc = v_T[k] + a_T[k] * t_zero_acc + 0.5 * j_zero_acc * t_zero_acc * t_zero_acc;
+        verboseprint("vel_zero_acc = {}\tt_zero_acc = {}".format(vel_zero_acc, t_zero_acc))
+    else:
+        vel_zero_acc = v_T[k]
+
+    #if v_d[k] > v_T[k]:
+    if v_d[k] > vel_zero_acc :
         j_max = abs(j_max)
     else:
         j_max = -abs(j_max)
@@ -323,12 +335,12 @@ for k in range(0, n):
 verboseprint('=========== END ===========')
 # Plot trajectory and desired setpoint
 plt.plot(t, v_d)
-plt.step(t, j_T)
+plt.plot(t, j_T, '*')
 plt.plot(t, a_T, '*')
 plt.plot(t, v_T)
 plt.plot(t, x_T)
-plt.step(arange (0.0, t_end+dt_0, dt_0), t)
-plt.step(t, j_T_corrected)
+plt.plot(arange (0.0, t_end+dt_0, dt_0), t)
+plt.plot(t, j_T_corrected)
 plt.legend(["v_d", "j_T", "a_T", "v_T", "x_T", "t"])
 plt.xlabel("time (s)")
 plt.ylabel("metric amplitude")

--- a/trajectory_generator/velocity_trajectory_generator.py
+++ b/trajectory_generator/velocity_trajectory_generator.py
@@ -240,9 +240,14 @@ v_d[0] = -2.0
 
 print_T123 = True
 
+dt_prev = dt
+sigma_jitter = 0.0
+#sigma_jitter = dt/10.0
+
 # Main loop
 for k in range(0, n-1):
     print('k = {}\tt = {}'.format(k, t[k]))
+    dt = dt + random.randn() * sigma_jitter # Add jitter
 
     # Change the desired velocity (simulate user RC sticks)
     if t[k] < 3.0:
@@ -274,23 +279,18 @@ for k in range(0, n-1):
         j_T[k] = -j_max_T1
     else:
         j_T[k] = 0.0
+        print('T123 = 0, t = {}\n'.format(t[k]))
+        print("T1 = {}\tT2 = {}\tT3 = {}\n".format(T1, T2, T3))
 
     # Integrate the trajectory
     (a_T[k+1], v_T[k+1], x_T_new) = integrate_T(j_T[k], a_T[k], v_T[k], x_T[k], k, dt, a_max, v_max)
 
-    # Lock the position setpoint if the error is bigger than some value
-    drone_position = 0.0
-    x_err = x_T_new - drone_position
-    if abs(x_err) > x_err_max:
-        x_T[k+1] = x_T[k]
-    else :
-        x_T[k+1] = x_T_new
+    dt_prev = dt
 
-T123 = 5.0
-T1 = computeT1_T123(T123, accel_prev=0.0, vel_prev=0.0, vel_setpoint=2.0, max_jerk=10.0)
-T3 = compute_T3(T1, 0.0, 10.0)
-T2 = compute_T2_T123(T123, T1, T3)
-print("T1 = {}\tT2 = {}\tT3 = {}\n".format(T1, T2, T3))
+# end loop
+
+
+print('=========== END ===========')
 # Plot trajectory and desired setpoint
 plt.step(t, v_d)
 plt.step(t, j_T)

--- a/trajectory_generator/velocity_trajectory_generator_symbolic.py
+++ b/trajectory_generator/velocity_trajectory_generator_symbolic.py
@@ -13,14 +13,14 @@ Description:
 
 from sympy import *
 
-j = Symbol("j", real=True)
-a_0 = Symbol("a_0", real=True)
-a_3 = Symbol("a_3", real=True)
-v_0 = Symbol("v_0", real=True)
-v_3 = Symbol("v_3", real=True)
-T_1 = Symbol("T_1", real=True)
-T_2 = Symbol("T_2", real=True)
-T_3 = Symbol("T_3", real=True)
+j = Symbol("j_max", real=True)
+a_0 = Symbol("a0", real=True)
+a_3 = Symbol("a3", real=True)
+v_0 = Symbol("v0", real=True)
+v_3 = Symbol("v3", real=True)
+T_1 = Symbol("T1", real=True)
+T_2 = Symbol("T2", real=True)
+T_3 = Symbol("T3", real=True)
 a_max = Symbol("a_max", real=True)
 
 f1 = a_0 + j*T_1 - j*T_3 - a_3
@@ -28,22 +28,37 @@ f1 = f1.subs(a_3, 0)
 res_T3 = solve(f1, T_3)
 res_T3 = res_T3[0]
 f2 = a_0*T_1 + j/2.0*T_1**2 + v_0 + a_0*T_2 + j*T_1*T_2 + a_0*T_3 + j*T_1*T_3 - j/2.0*T_3**2 - v_3
+f2 = f2.subs([(v_0, 0)])
 print("Step 1 - Setting T_2 = 0, compute T_1 as follows:")
 res_T1 = solve(f2.subs([(T_2, 0), (T_3, res_T3)]), T_1)
 res_T1 = res_T1[0]
 print("T_1 =")
 pprint(res_T1)
+print(res_T1)
+print("If jerk is too large, recompute it for fixed T1. New jerk = {}")
+res_j1 = solve(f2.subs([(T_2, 0), (T_3, res_T3)]), j)
+pprint(res_j1[0])
+print(res_j1[0])
+res1_T1 = solve(f1, T_1)
+res1_T1 = res1_T1[0]
+res_j3 = solve(f2.subs([(T_2, 0), (T_1, res1_T1)]), j)
+print("If jerk is too large, and T1 = 0. New jerk = {}")
+pprint(res_j3[0])
+print(res_j3[0])
 print("Step 2 - Check for saturation. If a_0 + j*T_1 > a_max, recompute T_1 using:")
 print("T_1 =")
 pprint(solve(a_0 + j*T_1 - a_max, T_1)[0])
+print(solve(a_0 + j*T_1 - a_max, T_1)[0])
 print("Step 3 - Compute T3 using:")
 print("T_3 =")
 pprint(res_T3)
+print(res_T3)
 res_T2 = solve(f2, T_2)
 res_T2 = res_T2[0]
 print("Step 3 - Finally compute the required constant acceleration part using:")
 print("T_2 =")
 pprint(res_T2)
+print(res_T2)
 
 dt = Symbol("dt", real=True)
 j_max = Symbol("j_max", real=True)
@@ -69,9 +84,9 @@ print("x_sp =")
 pprint(f_x_sp)
 
 print("=============== Time synchronization ===============")
-T = Symbol("T", real=True) # Total time
+T123 = Symbol("T123", real=True) # Total time
 
-f3 = T - T_1 - T_2 - T_3 # Time constraint
+f3 = T123 - T_1 - T_2 - T_3 # Time constraint
 res_T2 = solve(f3.subs(T_3, res_T3), T_2)
 res_T2 = res_T2[0]
 res_T1 = solve(f2.subs([(T_2, res_T2), (T_3, res_T3)]), T_1)
@@ -80,7 +95,9 @@ print("For multiple axes applications, we need to synchronize the trajectories s
 Given the total time of the longest trajectory T, we can solve again T_1, T_2 and T_3 for the other axes:")
 print("T_1 =")
 pprint(res_T1)
+print(res_T1)
 print("T_3 =")
 pprint(res_T3)
+print(res_T2)
 print("T_2 =")
 pprint(solve(f3, T_2)[0])

--- a/trajectory_generator/velocity_trajectory_generator_symbolic.py
+++ b/trajectory_generator/velocity_trajectory_generator_symbolic.py
@@ -23,11 +23,22 @@ T_2 = Symbol("T2", real=True)
 T_3 = Symbol("T3", real=True)
 a_max = Symbol("a_max", real=True)
 
+# Final acceleration (at t3)
 f1 = a_0 + j*T_1 - j*T_3 - a_3
-f1 = f1.subs(a_3, 0)
+f1 = f1.subs(a_3, 0) # Force final acceleration to be null
 res_T3 = solve(f1, T_3)
 res_T3 = res_T3[0]
-f2 = a_0*T_1 + j/2.0*T_1**2 + v_0 + a_0*T_2 + j*T_1*T_2 + a_0*T_3 + j*T_1*T_3 - j/2.0*T_3**2 - v_3
+# Acceleration at t1
+at1 = a_0 + j*T_1
+# Acceleration at t2
+at2 = at1
+# Velocity at t1
+vt1 = v_0 + a_0*T_1 + 0.5*j*T_1**2
+# Velocity at t2
+vt2 = vt1 + at1*T_2
+# Velocity at t3
+vt3 = vt2 + at2*T_3 - 0.5*j*T_3**2
+f2 = vt3 - v_3
 f2 = f2.subs([(v_0, 0)])
 print("Step 1 - Setting T_2 = 0, compute T_1 as follows:")
 res_T1 = solve(f2.subs([(T_2, 0), (T_3, res_T3)]), T_1)

--- a/trajectory_generator/velocity_trajectory_generator_symbolic.py
+++ b/trajectory_generator/velocity_trajectory_generator_symbolic.py
@@ -18,6 +18,7 @@ a_0 = Symbol("a0", real=True)
 a_3 = Symbol("a3", real=True)
 v_0 = Symbol("v0", real=True)
 v_3 = Symbol("v3", real=True)
+x_0 = Symbol("x0", real=True)
 T_1 = Symbol("T1", real=True)
 T_2 = Symbol("T2", real=True)
 T_3 = Symbol("T3", real=True)
@@ -38,6 +39,13 @@ vt1 = v_0 + a_0*T_1 + 0.5*j*T_1**2
 vt2 = vt1 + at1*T_2
 # Velocity at t3
 vt3 = vt2 + at2*T_3 - 0.5*j*T_3**2
+# Position at t1
+xt1 = x_0 + v_0*T_1 + 0.5*a_0*T_1**2 + 1/6*j*T_1**3
+# Position at t2
+xt2 = xt1 + vt1*T_2 + 0.5*at1*T_2**2
+# Position at t3
+xt3 = xt2 + vt2*T_3 + 0.5*at2*T_3**2 - 1/6*j*T_3**3
+
 f2 = vt3 - v_3
 f2 = f2.subs([(v_0, 0)])
 print("Step 1 - Setting T_2 = 0, compute T_1 as follows:")


### PR DESCRIPTION
A lot of stuff I was casually working on. It's not super clean but it's better if I merge it now.

Summary of the PR:
- algorithm moved into a class
- use polynomial evaluation instead of numerical integration to generate the trajectory from T1, T2 and T3. This solves the numerical issues created by large dt, large jerk, small delta velocities, time jitter, etc.

With numerical integration (and a lot of "special case handling":
![traj_num_integr](https://user-images.githubusercontent.com/14822839/61827222-5656c300-ae64-11e9-9a35-a3dd7fd982f3.png)

With polynomial evaluation (no need for special logic):
![traj_poly](https://user-images.githubusercontent.com/14822839/61827210-522aa580-ae64-11e9-8ea8-c951ed3f9210.png)

(This only shows the rounding issue due to large dt)