### PR TITLE
Create hover thrust estimator

### DIFF
--- a/hover_thrust_estimator/HoverThrEstimator.py
+++ b/hover_thrust_estimator/HoverThrEstimator.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+File: HoverThrEstimator.py
+Author: Mathieu Bresciani
+Email: brescianimathieu@gmail.com
+Github: https://github.com/bresch
+Description:
+    2-state hover thrust estimator
+    states: hover thrust (Th) and mass coefficient (Cm)
+    The mass coefficient is used to convert from normalized thrust
+    to acceleration.
+    The measurement is the vertical acceleration and the current
+    thrust (T[k]) is used in the measurement model.
+    Both states are noise driven: Transition matrix A = eye(2)
+    x[k+1] = Ax[k] + v with v ~ N(0, Q)
+    y[k] = h(u, x) + w with w ~ N(0, R)
+    Where the measurement model and corresponding Jocobian are:
+    h(u, x) = (T[k] - Th[k]) * Cm[k]
+    H[k] = [-Cm[k], T[k] - Th[k]]
+
+    Observability:
+    Cm is observable dynamically (T != Th)
+    Th is observable statically (T == Th)
+"""
+
+from numpy import *
+import sys
+import math
+import matplotlib.pylab as plt
+
+FLT_EPSILON = sys.float_info.epsilon
+NAN = float('nan')
+verbose = True;
+
+if verbose:
+    def verboseprint(*args):
+        # Print each argument separately so caller doesn't need to
+        # stuff everything to be printed into a single string
+        for arg in args:
+           print arg,
+        print
+else:
+    verboseprint = lambda *a: None      # do-nothing function
+
+class HoverThrEstimator(object):
+
+    def setState(self, hover_thr, mass_coeff):
+        self._hover_thr = hover_thr
+        self._mass_coeff = mass_coeff
+
+    def setStateVar(self, hover_thr_var, mass_coeff_var):
+        self._P = matrix([[hover_thr_var, 0.0],
+                         [0.0, mass_coeff_var]])
+
+    def setProcessVar(self, hover_thr_process_noise_var, mass_coeff_process_noise_var):
+        self._Q = matrix([[hover_thr_process_noise_var, 0.0], [0.0, mass_coeff_process_noise_var]])
+
+    def setMeasVar(self, accel_var):
+        self._R = accel_var
+
+    def __init__(self, hover_thr, mass_coeff):
+        self.setState(hover_thr, mass_coeff)
+        self.setStateVar(0.05, 101.0)
+        self.setProcessVar(0.3**2, 1.0**2)
+        self.setMeasVar(0.02)
+
+    def predict(self, dt):
+        # States are constant
+        # Predict error covariance only
+        self._P += self._Q * dt
+
+    def fuseAccZ(self, acc_z, thrust):
+        H = matrix([[-self._mass_coeff, thrust - self._hover_thr]])
+        acc_innov_var = H * self._P * H.T + self._R
+        acc_innov_var = max(acc_innov_var, self._R)
+        acc_innov = self.predictedAccZ(thrust) - acc_z
+
+        kalman_gain = self._P * H.T / acc_innov_var
+
+        # Update states
+        # TODO: hover_thr is by definition between 0 and 1
+        # and it should always be between 0.15(racer) and 0.7(heavy)
+        self._hover_thr -= kalman_gain.item(0) * acc_innov
+        self._mass_coeff -= kalman_gain.item(1) * acc_innov
+
+        # Update covariances
+        self._P = maximum((eye(2) - kalman_gain * H) * self._P, self._P)
+
+    def predictedAccZ(self, thrust):
+        return thrust * self._mass_coeff - self._hover_thr * self._mass_coeff
+
+
+if __name__ == '__main__':
+    hover_thr_0 = 0.5
+    mass_coeff_0 = 0.4
+    hover_ekf = HoverThrEstimator(hover_thr_0, mass_coeff_0)
+    assert hover_ekf._hover_thr == hover_thr_0
+    assert hover_ekf._mass_coeff == mass_coeff_0
+
+    hover_thr_noise_0 = 0.2
+    mass_coeff_noise_0 = 10.0
+    hover_ekf.setStateVar(hover_thr_noise_0**2, mass_coeff_noise_0**2)
+
+    assert (hover_ekf._P == matrix([[hover_thr_noise_0**2, 0.0],
+                                  [0.0, mass_coeff_noise_0**2]])).all()
+
+    hover_thr_process_noise = 0.01
+    mass_coeff_process_noise = 0.1
+    hover_ekf.setProcessVar(hover_thr_process_noise**2, mass_coeff_process_noise**2)
+    assert (hover_ekf._Q == matrix([[hover_thr_process_noise**2, 0.0],
+                                    [0.0, mass_coeff_process_noise**2]])).all()
+
+    dt = 0.01
+    hover_ekf.predict(dt)
+    assert hover_ekf._hover_thr == hover_thr_0
+    assert hover_ekf._mass_coeff == mass_coeff_0
+    assert (hover_ekf._P == matrix([[hover_thr_noise_0**2 + hover_thr_process_noise**2 * dt, 0.0],
+                                  [0.0, mass_coeff_noise_0**2 + mass_coeff_process_noise**2 * dt]])).all()
+
+    accel_noise = 0.1
+    hover_ekf.setMeasVar(accel_noise**2)
+    assert hover_ekf._R == accel_noise**2
+
+    hover_ekf.fuseAccZ(0.0, hover_thr_0)
+    assert hover_ekf._hover_thr == hover_thr_0
+    assert hover_ekf._mass_coeff == mass_coeff_0

--- a/hover_thrust_estimator/HoverThrEstimator.py
+++ b/hover_thrust_estimator/HoverThrEstimator.py
@@ -7,22 +7,16 @@ Author: Mathieu Bresciani
 Email: brescianimathieu@gmail.com
 Github: https://github.com/bresch
 Description:
-    2-state hover thrust estimator
-    states: hover thrust (Th) and mass coefficient (Cm)
-    The mass coefficient is used to convert from normalized thrust
-    to acceleration.
+    1-state hover thrust estimator
+    state: hover thrust (Th)
     The measurement is the vertical acceleration and the current
     thrust (T[k]) is used in the measurement model.
-    Both states are noise driven: Transition matrix A = eye(2)
+    The sate is noise driven: Transition matrix A = 1
     x[k+1] = Ax[k] + v with v ~ N(0, Q)
     y[k] = h(u, x) + w with w ~ N(0, R)
     Where the measurement model and corresponding Jocobian are:
-    h(u, x) = (T[k] - Th[k]) * Cm[k]
-    H[k] = [-Cm[k], T[k] - Th[k]]
-
-    Observability:
-    Cm is observable dynamically (T != Th)
-    Th is observable statically (T == Th)
+    h(u, x) = g * T[k] / Th[k] - g
+    H[k] = -g * T[k] / Th[k]**2
 """
 
 from numpy import *
@@ -46,78 +40,66 @@ else:
 
 class HoverThrEstimator(object):
 
-    def setState(self, hover_thr, mass_coeff):
+    def setState(self, hover_thr):
         self._hover_thr = hover_thr
-        self._mass_coeff = mass_coeff
 
-    def setStateVar(self, hover_thr_var, mass_coeff_var):
-        self._P = matrix([[hover_thr_var, 0.0],
-                         [0.0, mass_coeff_var]])
+    def setStateVar(self, hover_thr_var):
+        self._P = hover_thr_var
 
-    def setProcessVar(self, hover_thr_process_noise_var, mass_coeff_process_noise_var):
-        self._Q = matrix([[hover_thr_process_noise_var, 0.0], [0.0, mass_coeff_process_noise_var]])
+    def setProcessVar(self, hover_thr_process_noise_var):
+        self._Q = hover_thr_process_noise_var
 
     def setMeasVar(self, accel_var):
         self._R = accel_var
 
-    def __init__(self, hover_thr, mass_coeff):
-        self.setState(hover_thr, mass_coeff)
-        self.setStateVar(0.05, 101.0)
-        self.setProcessVar(0.3**2, 1.0**2)
+    def __init__(self, hover_thr):
+        self.setState(hover_thr)
+        self.setStateVar(0.05)
+        self.setProcessVar(0.3**2)
         self.setMeasVar(0.02)
 
     def predict(self, dt):
-        # States are constant
+        # State is constant
         # Predict error covariance only
         self._P += self._Q * dt
 
     def fuseAccZ(self, acc_z, thrust):
-        H = matrix([[-self._mass_coeff, thrust - self._hover_thr]])
-        acc_innov_var = H * self._P * H.T + self._R
+        H = -9.81 * thrust / (self._hover_thr**2)
+        acc_innov_var = H * self._P * H + self._R
         acc_innov_var = max(acc_innov_var, self._R)
         acc_innov = self.predictedAccZ(thrust) - acc_z
 
-        kalman_gain = self._P * H.T / acc_innov_var
+        kalman_gain = self._P * H / acc_innov_var
 
-        # Update states
-        # TODO: hover_thr is by definition between 0 and 1
-        # and it should always be between 0.15(racer) and 0.7(heavy)
-        self._hover_thr -= kalman_gain.item(0) * acc_innov
-        self._mass_coeff -= kalman_gain.item(1) * acc_innov
+        # Update state
+        self._hover_thr -= kalman_gain * acc_innov
+        self._hover_thr = clip(self._hover_thr, 0.1, 0.8)
 
         # Update covariances
-        self._P = maximum((eye(2) - kalman_gain * H) * self._P, zeros((2, 2)))
+        self._P = max((1.0 - kalman_gain * H) * self._P, 0.0)
 
     def predictedAccZ(self, thrust):
-        return thrust * self._mass_coeff - self._hover_thr * self._mass_coeff
+        return 9.81 * thrust / self._hover_thr - 9.81
 
 
 if __name__ == '__main__':
     hover_thr_0 = 0.5
-    mass_coeff_0 = 0.4
-    hover_ekf = HoverThrEstimator(hover_thr_0, mass_coeff_0)
+    hover_ekf = HoverThrEstimator(hover_thr_0)
     assert hover_ekf._hover_thr == hover_thr_0
-    assert hover_ekf._mass_coeff == mass_coeff_0
 
     hover_thr_noise_0 = 0.2
-    mass_coeff_noise_0 = 10.0
-    hover_ekf.setStateVar(hover_thr_noise_0**2, mass_coeff_noise_0**2)
+    hover_ekf.setStateVar(hover_thr_noise_0**2)
 
-    assert (hover_ekf._P == matrix([[hover_thr_noise_0**2, 0.0],
-                                  [0.0, mass_coeff_noise_0**2]])).all()
+    assert hover_ekf._P == hover_thr_noise_0**2
 
     hover_thr_process_noise = 0.01
-    mass_coeff_process_noise = 0.1
-    hover_ekf.setProcessVar(hover_thr_process_noise**2, mass_coeff_process_noise**2)
-    assert (hover_ekf._Q == matrix([[hover_thr_process_noise**2, 0.0],
-                                    [0.0, mass_coeff_process_noise**2]])).all()
+    hover_ekf.setProcessVar(hover_thr_process_noise**2)
+    assert hover_ekf._Q == hover_thr_process_noise**2
 
     dt = 0.01
     hover_ekf.predict(dt)
     assert hover_ekf._hover_thr == hover_thr_0
-    assert hover_ekf._mass_coeff == mass_coeff_0
-    assert (hover_ekf._P == matrix([[hover_thr_noise_0**2 + hover_thr_process_noise**2 * dt, 0.0],
-                                  [0.0, mass_coeff_noise_0**2 + mass_coeff_process_noise**2 * dt]])).all()
+    assert hover_ekf._P == hover_thr_noise_0**2 + hover_thr_process_noise**2 * dt
 
     accel_noise = 0.1
     hover_ekf.setMeasVar(accel_noise**2)
@@ -125,4 +107,3 @@ if __name__ == '__main__':
 
     hover_ekf.fuseAccZ(0.0, hover_thr_0)
     assert hover_ekf._hover_thr == hover_thr_0
-    assert hover_ekf._mass_coeff == mass_coeff_0

--- a/hover_thrust_estimator/HoverThrEstimator.py
+++ b/hover_thrust_estimator/HoverThrEstimator.py
@@ -86,7 +86,7 @@ class HoverThrEstimator(object):
         self._mass_coeff -= kalman_gain.item(1) * acc_innov
 
         # Update covariances
-        self._P = maximum((eye(2) - kalman_gain * H) * self._P, self._P)
+        self._P = maximum((eye(2) - kalman_gain * H) * self._P, zeros((2, 2)))
 
     def predictedAccZ(self, thrust):
         return thrust * self._mass_coeff - self._hover_thr * self._mass_coeff

--- a/hover_thrust_estimator/hover_thrust_replay.py
+++ b/hover_thrust_estimator/hover_thrust_replay.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+File: hover_thrust_replay.py
+Author: Mathieu Bresciani
+Email: brescianimathieu@gmail.com
+Github: https://github.com/bresch
+Description:
+"""
+
+from numpy import *
+import matplotlib.pylab as plt
+from HoverThrEstimator import HoverThrEstimator
+from pyulog import ULog
+import os
+
+
+def get_data(log, topic_name, variable_name):
+    for elem in log.data_list:
+        if elem.name == topic_name:
+            variable_data = elem.data[variable_name]
+            break
+
+    return variable_data
+
+def ms2s_list(time_ms_list):
+    return [i*1e-6 for i in time_ms_list]
+
+def run(log_name, showplots):
+    log = ULog(log_name)
+
+    # Select msgs and copy into arrays
+    thrust = -get_data(log, 'vehicle_local_position_setpoint', 'thrust[2]')
+    az = -get_data(log, 'vehicle_local_position', 'az')
+    dist_bottom = get_data(log, 'vehicle_local_position', 'dist_bottom')
+    t = ms2s_list(get_data(log, 'vehicle_local_position_setpoint', 'timestamp'))
+    t_ekf = ms2s_list(get_data(log, 'vehicle_local_position', 'timestamp'))
+
+    # Downsample ekf estimate to setpoint sample rate
+    accel = array(interp(t, t_ekf, az))
+
+    # Estimator initial conditions
+    hover_thrust_0 = 0.5
+    hover_thrust_noise_0 = 0.1
+    P0 = hover_thrust_noise_0**2
+    hover_thrust_process_noise = sqrt(0.25e-6) # hover thrust change / s
+    Q = hover_thrust_process_noise**2
+    Qk = Q
+    accel_noise_0 = sqrt(5.0)
+    R = accel_noise_0**2 # Rk = R
+
+    hover_ekf = HoverThrEstimator(hover_thrust_0)
+    hover_ekf.setStateVar(P0)
+    hover_ekf.setProcessVar(Qk)
+    hover_ekf.setMeasVar(R)
+
+    # Initialize arrays
+    n = len(t)
+    accel_true = zeros(n)
+    hover_thrust = zeros(n)
+    hover_thrust_std = zeros(n)
+    hover_thrust_true = zeros(n)
+    accel_noise_std = zeros(n)
+    innov = zeros(n)
+    innov_std = zeros(n)
+    innov_test_ratio = zeros(n)
+    innov_test_ratio_signed_lpf = zeros(n)
+    residual_lpf = zeros(n)
+
+    for k in range(1, n-100):
+        # Save data
+        hover_thrust[k] = hover_ekf._hover_thr
+        hover_thrust_std[k] = sqrt(hover_ekf._P)
+        dt = t[k] - t[k-1]
+
+        if dist_bottom[k] > 1.0:
+            # Update the EKF
+            hover_ekf.predict(dt)
+            (innov[k], innov_var, innov_test_ratio[k]) = hover_ekf.fuseAccZ(accel[k], thrust[k])
+
+            innov_std[k] = sqrt(innov_var)
+            accel_noise_std[k] = sqrt(hover_ekf._R)
+            innov_test_ratio_signed_lpf[k] = hover_ekf._innov_test_ratio_signed_lpf
+            residual_lpf[k] = hover_ekf._residual_lpf
+
+    if showplots:
+        head_tail = os.path.split(log_name)
+        plotData(t, thrust, accel, accel_noise_std, hover_thrust, hover_thrust_std, innov_test_ratio, innov_test_ratio_signed_lpf, innov, innov_std, residual_lpf, head_tail[1])
+
+def plotData(t, thrust, accel, accel_noise_std, hover_thrust, hover_thrust_std, innov_test_ratio, innov_test_ratio_signed_lpf, innov, innov_std, residual_lpf, log_name):
+    n_plots = 5
+    ax1 = plt.subplot(n_plots, 1, 1)
+    ax1.plot(t, thrust * 10.0, '.')
+    ax1.plot(t, accel, '.')
+    ax1.plot(t, 3*accel_noise_std, 'g--')
+    ax1.plot(t, -3*accel_noise_std, 'g--')
+    ax1.legend(["Thrust (10x)", "AccZ", "Acc noise est"])
+    plt.title(log_name)
+
+    ax2 = plt.subplot(n_plots, 1, 2, sharex=ax1)
+    ax2.plot(t, hover_thrust, 'b')
+    ax2.plot(t, hover_thrust + hover_thrust_std, 'g--')
+    ax2.plot(t, hover_thrust - hover_thrust_std, 'g--')
+    ax2.legend(["Ht_Est"])
+
+    ax3 = plt.subplot(n_plots, 1, 3, sharex=ax1)
+    ax3.plot(t, hover_thrust_std)
+    ax3.legend(["Ht_noise"])
+
+    ax4 = plt.subplot(n_plots, 1, 4, sharex=ax1)
+    ax4.plot(t, innov_test_ratio)
+    ax4.plot(t, innov_test_ratio_signed_lpf)
+    ax4.plot(t, residual_lpf)
+    ax4.legend(["Test ratio", "Test ratio lpf", "Residual lpf"])
+
+    ax5 = plt.subplot(n_plots, 1, 5, sharex=ax1)
+    ax5.plot(t, innov)
+    ax5.plot(t, innov + innov_std, 'g--')
+    ax5.plot(t, innov - innov_std, 'g--')
+    ax5.legend(["Innov"])
+
+    plt.show()
+
+if __name__ == '__main__':
+    import argparse
+
+    # Get the path of this script (without file name)
+    script_path = os.path.split(os.path.realpath(__file__))[0]
+
+    # Parse arguments
+    parser = argparse.ArgumentParser(
+        description='Estimate mag biases from ULog file')
+
+    # Provide parameter file path and name
+    parser.add_argument('logfile', help='Full ulog file path, name and extension', type=str)
+    parser.add_argument('--showplots', help='Display relevant plots',
+                        action='store_true')
+    args = parser.parse_args()
+
+    logfile = os.path.abspath(args.logfile) # Convert to absolute path
+
+    run(logfile, args.showplots)

--- a/hover_thrust_estimator/hover_thrust_sim.py
+++ b/hover_thrust_estimator/hover_thrust_sim.py
@@ -12,6 +12,9 @@ Description:
     using the same model as the estimator but with noise:
 
     accel = (Thrust - Hover thrust) * mass coefficient + noise
+    where the mass coefficient is g / Hover thrust
+    which gives
+    accel = g * Thrust / Hover thrust - g
 """
 
 from numpy import *
@@ -19,7 +22,7 @@ import matplotlib.pylab as plt
 from HoverThrEstimator import HoverThrEstimator
 
 def getAccelFromThrTime(thrust, t):
-    accel = (thrust - hover_thr_true) * mass_coeff_true
+    accel = 9.81 * thrust / hover_thr_true - 9.81
 
     return accel
 
@@ -44,42 +47,34 @@ def getThrFromTime(t):
 
 if __name__ == '__main__':
     # Simulation parameters
-    dt = 0.10
+    dt = 0.03
     t_end = 4.0
     t = arange (0.0, t_end+dt, dt)
     n = len(t)
 
-    hover_thr_true = 0.6
-    mass_coeff_true = 16.0
+    hover_thr_true = 0.42
 
     # Estimator initial conditions
     hover_thr_0 = 0.5
-    mass_coeff_0 = 20.0
     hover_thr_noise_0 = 0.2
-    mass_coeff_noise_0 = 10.0
-    hover_thr_process_noise = 0.02
-    mass_coeff_process_noise = 1.0
+    hover_thr_process_noise = 0.01
     accel_noise = 3.5e-1
 
-    hover_ekf = HoverThrEstimator(hover_thr_0, mass_coeff_0)
-    hover_ekf.setStateVar(hover_thr_noise_0**2, mass_coeff_noise_0**2)
-    hover_ekf.setProcessVar(hover_thr_process_noise**2, mass_coeff_process_noise**2)
+    hover_ekf = HoverThrEstimator(hover_thr_0)
+    hover_ekf.setStateVar(hover_thr_noise_0**2)
+    hover_ekf.setProcessVar(hover_thr_process_noise**2)
     hover_ekf.setMeasVar(accel_noise**2)
 
     # Create data buckets
     accel = zeros(n)
     thrust = ones(n)
     hover_thr = zeros(n)
-    mass_coeff = zeros(n)
     hover_thr_std = zeros(n)
-    mass_coeff_std = zeros(n)
 
     for k in range(0, n):
         # Save data
         hover_thr[k] = hover_ekf._hover_thr
-        mass_coeff[k] = hover_ekf._mass_coeff
-        hover_thr_std[k] = sqrt(hover_ekf._P.item(0, 0))
-        mass_coeff_std[k] = sqrt(hover_ekf._P.item(1, 1))
+        hover_thr_std[k] = sqrt(hover_ekf._P)
 
         # Generate measurement
         thrust[k] = getThrFromTime(t[k])
@@ -91,22 +86,16 @@ if __name__ == '__main__':
         hover_ekf.fuseAccZ(accel[k], thrust[k])
 
     # Plot results
-    ax1 = plt.subplot(3, 1, 1)
+    ax1 = plt.subplot(2, 1, 1)
     ax1.plot(t, thrust * 10.0, '.')
     ax1.plot(t, accel, '.')
     ax1.legend(["Thrust (10x)", "AccZ"])
 
-    ax2 = plt.subplot(3, 1, 2, sharex=ax1)
+    ax2 = plt.subplot(2, 1, 2, sharex=ax1)
     ax2.plot(t, hover_thr, 'b')
     ax2.plot(t, hover_thr_true * ones(n), 'k:')
     ax2.plot(t, hover_thr + hover_thr_std, 'g--')
     ax2.plot(t, hover_thr - hover_thr_std, 'g--')
     plt.legend(["Ht_Est", "Ht_True"])
 
-    ax3 = plt.subplot(3, 1, 3, sharex=ax1)
-    ax3.plot(t, mass_coeff, 'r')
-    ax3.plot(t, mass_coeff_true * ones(n), 'k:')
-    ax3.plot(t, mass_coeff + mass_coeff_std, '--', color="tab:orange")
-    ax3.plot(t, mass_coeff - mass_coeff_std, '--', color="tab:orange")
-    plt.legend(["Cm_Est", "Cm_True"])
     plt.show()

--- a/hover_thrust_estimator/hover_thrust_sim.py
+++ b/hover_thrust_estimator/hover_thrust_sim.py
@@ -39,6 +39,8 @@ def getThrFromTime(t):
     elif t < 4.0:
         thrust = 0.5 - (t - 2.5) * 0.25
 
+    elif t < 6.0:
+        thrust = 0.42
     else:
         thrust = 0.0
 
@@ -48,7 +50,7 @@ def getThrFromTime(t):
 if __name__ == '__main__':
     # Simulation parameters
     dt = 0.03
-    t_end = 4.0
+    t_end = 8.0
     t = arange (0.0, t_end+dt, dt)
     n = len(t)
 
@@ -63,7 +65,7 @@ if __name__ == '__main__':
     hover_ekf = HoverThrEstimator(hover_thr_0)
     hover_ekf.setStateVar(hover_thr_noise_0**2)
     hover_ekf.setProcessVar(hover_thr_process_noise**2)
-    hover_ekf.setMeasVar(accel_noise**2)
+    hover_ekf.setMeasVar((10.0 * accel_noise)**2)
 
     # Create data buckets
     accel = zeros(n)
@@ -79,11 +81,14 @@ if __name__ == '__main__':
         # Generate measurement
         thrust[k] = getThrFromTime(t[k])
         noise = random.randn() * accel_noise
+        if t[k] > 1.5:
+            hover_thr_true = 0.6
         accel[k] = getAccelFromThrTime(thrust[k], t[k]) + noise
 
         # Update the EKF
         hover_ekf.predict(dt)
         hover_ekf.fuseAccZ(accel[k], thrust[k])
+        print("P = ", hover_ekf._P, "\tQ = ", hover_ekf._Q, "\tR = ", hover_ekf._R)
 
     # Plot results
     ax1 = plt.subplot(2, 1, 1)

--- a/hover_thrust_estimator/hover_thrust_sim.py
+++ b/hover_thrust_estimator/hover_thrust_sim.py
@@ -77,7 +77,7 @@ if __name__ == '__main__':
     hover_thrust_std = zeros(n)
     hover_thrust_true = zeros(n)
     accel_noise_std = zeros(n)
-    innov_test_ratio_lpf = zeros(n)
+    innov_test_ratio_signed_lpf = zeros(n)
     innov = zeros(n)
     innov_std = zeros(n)
     innov_test_ratio = zeros(n)
@@ -106,7 +106,7 @@ if __name__ == '__main__':
         (innov[k], innov_var, innov_test_ratio[k]) = hover_ekf.fuseAccZ(accel[k], thrust[k])
         innov_std[k] = sqrt(innov_var)
         accel_noise_std[k] = sqrt(hover_ekf._R)
-        innov_test_ratio_lpf[k] = hover_ekf._innov_test_ratio_lpf
+        innov_test_ratio_signed_lpf[k] = hover_ekf._innov_test_ratio_signed_lpf
         residual_lpf[k] = hover_ekf._residual_lpf
         # print("P = ", hover_ekf._P, "\tQ = ", hover_ekf._Q, "\tsqrt(R) = ", sqrt(hover_ekf._R))
 
@@ -132,14 +132,13 @@ if __name__ == '__main__':
 
     ax4 = plt.subplot(n_plots, 1, 4, sharex=ax1)
     ax4.plot(t, innov_test_ratio)
-    ax4.plot(t, innov_test_ratio_lpf)
+    ax4.plot(t, innov_test_ratio_signed_lpf)
     ax4.plot(t, residual_lpf)
     ax4.legend(["Test ratio", "Test ratio lpf", "Residual lpf"])
 
     ax5 = plt.subplot(n_plots, 1, 5, sharex=ax1)
     ax5.plot(t, innov)
-    ax5.plot(t, innov + innov_std, 'g--')
-    ax5.plot(t, innov - innov_std, 'g--')
     ax5.legend(["Innov"])
+    ax5.grid()
 
     plt.show()

--- a/hover_thrust_estimator/hover_thrust_sim.py
+++ b/hover_thrust_estimator/hover_thrust_sim.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+File: hover_thrust_sim.py
+Author: Mathieu Bresciani
+Email: brescianimathieu@gmail.com
+Github: https://github.com/bresch
+Description:
+    Simple simulation of for the HoverThrEstimator class.
+    A thrust curve is generated and produces acceleration
+    using the same model as the estimator but with noise:
+
+    accel = (Thrust - Hover thrust) * mass coefficient + noise
+"""
+
+from numpy import *
+import matplotlib.pylab as plt
+from HoverThrEstimator import HoverThrEstimator
+
+def getAccelFromThrTime(thrust, t):
+    accel = (thrust - hover_thr_true) * mass_coeff_true
+
+    return accel
+
+def getThrFromTime(t):
+    if t < 0.6:
+        thrust = t
+
+    elif t < 1.5:
+        thrust = 0.6
+
+    elif t < 2.5:
+        thrust = 0.5
+
+    elif t < 4.0:
+        thrust = 0.5 - (t - 2.5) * 0.25
+
+    else:
+        thrust = 0.0
+
+    return thrust
+
+
+if __name__ == '__main__':
+    # Simulation parameters
+    dt = 0.10
+    t_end = 4.0
+    t = arange (0.0, t_end+dt, dt)
+    n = len(t)
+
+    hover_thr_true = 0.6
+    mass_coeff_true = 16.0
+
+    # Estimator initial conditions
+    hover_thr_0 = 0.5
+    mass_coeff_0 = 20.0
+    hover_thr_noise_0 = 0.2
+    mass_coeff_noise_0 = 10.0
+    hover_thr_process_noise = 0.02
+    mass_coeff_process_noise = 1.0
+    accel_noise = 3.5e-1
+
+    hover_ekf = HoverThrEstimator(hover_thr_0, mass_coeff_0)
+    hover_ekf.setStateVar(hover_thr_noise_0**2, mass_coeff_noise_0**2)
+    hover_ekf.setProcessVar(hover_thr_process_noise**2, mass_coeff_process_noise**2)
+    hover_ekf.setMeasVar(accel_noise**2)
+
+    # Create data buckets
+    accel = zeros(n)
+    thrust = ones(n)
+    hover_thr = zeros(n)
+    mass_coeff = zeros(n)
+    hover_thr_std = zeros(n)
+    mass_coeff_std = zeros(n)
+
+    for k in range(0, n):
+        # Save data
+        hover_thr[k] = hover_ekf._hover_thr
+        mass_coeff[k] = hover_ekf._mass_coeff
+        hover_thr_std[k] = sqrt(hover_ekf._P.item(0, 0))
+        mass_coeff_std[k] = sqrt(hover_ekf._P.item(1, 1))
+
+        # Generate measurement
+        thrust[k] = getThrFromTime(t[k])
+        noise = random.randn() * accel_noise
+        accel[k] = getAccelFromThrTime(thrust[k], t[k]) + noise
+
+        # Update the EKF
+        hover_ekf.predict(dt)
+        hover_ekf.fuseAccZ(accel[k], thrust[k])
+
+    # Plot results
+    ax1 = plt.subplot(3, 1, 1)
+    ax1.plot(t, thrust * 10.0, '.')
+    ax1.plot(t, accel, '.')
+    ax1.legend(["Thrust (10x)", "AccZ"])
+
+    ax2 = plt.subplot(3, 1, 2, sharex=ax1)
+    ax2.plot(t, hover_thr, 'b')
+    ax2.plot(t, hover_thr_true * ones(n), 'k:')
+    ax2.plot(t, hover_thr + hover_thr_std, 'g--')
+    ax2.plot(t, hover_thr - hover_thr_std, 'g--')
+    plt.legend(["Ht_Est", "Ht_True"])
+
+    ax3 = plt.subplot(3, 1, 3, sharex=ax1)
+    ax3.plot(t, mass_coeff, 'r')
+    ax3.plot(t, mass_coeff_true * ones(n), 'k:')
+    ax3.plot(t, mass_coeff + mass_coeff_std, '--', color="tab:orange")
+    ax3.plot(t, mass_coeff - mass_coeff_std, '--', color="tab:orange")
+    plt.legend(["Cm_Est", "Cm_True"])
+    plt.show()

--- a/hover_thrust_estimator/hover_thrust_sim.py
+++ b/hover_thrust_estimator/hover_thrust_sim.py
@@ -27,24 +27,20 @@ def getAccelFromThrTime(thrust, t, ht):
     return accel
 
 def getThrFromTime(t):
-    if t < 0.6:
-        thrust = t
-
-    elif t < 1.5:
-        thrust = 0.6
-
-    elif t < 2.5:
+    if t <= 10.0:
+        thrust = 0.8
+    else:
         thrust = 0.5
 
-    elif t < 4.0:
-        thrust = 0.5 - (t - 2.5) * 0.25
-
-    elif t < 6.0:
-        thrust = 0.42
-    else:
-        thrust = 0.8
-
     return thrust
+
+def getHoverThrustFromTime(t):
+    if t <= 10.0:
+        hover_t = 0.8
+    else:
+        hover_t = 0.5
+
+    return hover_t
 
 
 if __name__ == '__main__':
@@ -56,66 +52,94 @@ if __name__ == '__main__':
 
 
     # Estimator initial conditions
-    hover_thr_0 = 0.5
-    hover_thr_noise_0 = 0.2
-    P0 = hover_thr_noise_0**2
-    hover_thr_process_noise = 0.01 # hover thrust change / s
-    Q = hover_thr_process_noise**2
-    Qk = Q * dt
-    accel_noise = 3.5e-1 # in m/s2
-    R = accel_noise**2 # Rk = R
+    hover_thrust_0 = 0.5
+    hover_thrust_noise_0 = 0.1
+    P0 = hover_thrust_noise_0**2
+    hover_thrust_process_noise = sqrt(0.25e-6) # hover thrust change / s
+    Q = hover_thrust_process_noise**2
+    Qk = Q
+    accel_noise_0 = sqrt(5.0)
+    R = accel_noise_0**2 # Rk = R
 
-    hover_ekf = HoverThrEstimator(hover_thr_0)
+    hover_ekf = HoverThrEstimator(hover_thrust_0)
     hover_ekf.setStateVar(P0)
     hover_ekf.setProcessVar(Qk)
     hover_ekf.setMeasVar(R)
+
+    accel_noise_sim = 2.0 # in m/s2
+    hover_thrust_sim = 0.8
 
     # Create data buckets
     accel = zeros(n)
     accel_true = zeros(n)
     thrust = ones(n)
-    hover_thr = zeros(n)
-    hover_thr_std = zeros(n)
-    hover_thr_true = zeros(n)
-    accel_noise_estimated = zeros(n)
+    hover_thrust = zeros(n)
+    hover_thrust_std = zeros(n)
+    hover_thrust_true = zeros(n)
+    accel_noise_std = zeros(n)
+    innov_test_ratio_lpf = zeros(n)
+    innov = zeros(n)
+    innov_std = zeros(n)
+    innov_test_ratio = zeros(n)
+    residual_lpf = zeros(n)
 
     for k in range(0, n):
         # Save data
-        hover_thr[k] = hover_ekf._hover_thr
-        hover_thr_std[k] = sqrt(hover_ekf._P)
+        hover_thrust[k] = hover_ekf._hover_thr
+        hover_thrust_std[k] = sqrt(hover_ekf._P)
 
         # Generate measurement
         thrust[k] = getThrFromTime(t[k])
-        noise = random.randn() * accel_noise
-        hover_thr_true[k] = 0.42 + 0.2 * (t[k]/t_end)
-        accel_true[k] = getAccelFromThrTime(thrust[k], t[k], hover_thr_true[k])
+        noise = random.randn() * accel_noise_sim
+        hover_thrust_true[k] = getHoverThrustFromTime(t[k])
+        accel_true[k] = getAccelFromThrTime(thrust[k], t[k], hover_thrust_true[k])
         accel[k] =  accel_true[k] + noise
 
         # Accel noise change
         if t[k] > 40.0:
-            accel_noise = 0.4
+            accel_noise_sim = 2.0
         elif t[k] > 30.0:
-            accel_noise = 2.5
+            accel_noise_sim = 4.0
 
         # Update the EKF
         hover_ekf.predict(dt)
-        hover_ekf.fuseAccZ(accel[k], thrust[k])
-        accel_noise_estimated[k] = sqrt(hover_ekf._R)
+        (innov[k], innov_var, innov_test_ratio[k]) = hover_ekf.fuseAccZ(accel[k], thrust[k])
+        innov_std[k] = sqrt(innov_var)
+        accel_noise_std[k] = sqrt(hover_ekf._R)
+        innov_test_ratio_lpf[k] = hover_ekf._innov_test_ratio_lpf
+        residual_lpf[k] = hover_ekf._residual_lpf
         # print("P = ", hover_ekf._P, "\tQ = ", hover_ekf._Q, "\tsqrt(R) = ", sqrt(hover_ekf._R))
 
     # Plot results
-    ax1 = plt.subplot(2, 1, 1)
+    n_plots = 5
+    ax1 = plt.subplot(n_plots, 1, 1)
     ax1.plot(t, thrust * 10.0, '.')
     ax1.plot(t, accel, '.')
-    ax1.plot(t, accel_true + accel_noise_estimated, 'g--')
-    ax1.plot(t, accel_true - accel_noise_estimated, 'g--')
+    ax1.plot(t, accel_true + 3*accel_noise_std, 'g--')
+    ax1.plot(t, accel_true - 3*accel_noise_std, 'g--')
     ax1.legend(["Thrust (10x)", "AccZ"])
 
-    ax2 = plt.subplot(2, 1, 2, sharex=ax1)
-    ax2.plot(t, hover_thr, 'b')
-    ax2.plot(t, hover_thr_true, 'k:')
-    ax2.plot(t, hover_thr + hover_thr_std, 'g--')
-    ax2.plot(t, hover_thr - hover_thr_std, 'g--')
-    plt.legend(["Ht_Est", "Ht_True"])
+    ax2 = plt.subplot(n_plots, 1, 2, sharex=ax1)
+    ax2.plot(t, hover_thrust, 'b')
+    ax2.plot(t, hover_thrust_true, 'k:')
+    ax2.plot(t, hover_thrust + hover_thrust_std, 'g--')
+    ax2.plot(t, hover_thrust - hover_thrust_std, 'g--')
+    ax2.legend(["Ht_Est", "Ht_True"])
+
+    ax3 = plt.subplot(n_plots, 1, 3, sharex=ax1)
+    ax3.plot(t, hover_thrust_std)
+    ax3.legend(["Ht_noise"])
+
+    ax4 = plt.subplot(n_plots, 1, 4, sharex=ax1)
+    ax4.plot(t, innov_test_ratio)
+    ax4.plot(t, innov_test_ratio_lpf)
+    ax4.plot(t, residual_lpf)
+    ax4.legend(["Test ratio", "Test ratio lpf", "Residual lpf"])
+
+    ax5 = plt.subplot(n_plots, 1, 5, sharex=ax1)
+    ax5.plot(t, innov)
+    ax5.plot(t, innov + innov_std, 'g--')
+    ax5.plot(t, innov - innov_std, 'g--')
+    ax5.legend(["Innov"])
 
     plt.show()


### PR DESCRIPTION
1-state hover thrust estimator
state: 
hover thrust (Th)

The measurement is the vertical acceleration and the current thrust (T[k]) is used in the measurement model.
    
The sate is noise driven: Transition matrix A = 1
```
    x[k+1] = Ax[k] + v with v ~ N(0, Q)
    y[k] = h(u, x) + w with w ~ N(0, R)
```
Where the measurement model and corresponding derivative are:
```
    h(u, x) = g * T[k] / Th[k] - g
    H[k] = -g * T[k] / Th[k]**2
```

Note:
We might want to "lag" the commanded thrust in order to virtually recreate the actual thrust by passing the commanded thrust through a simple 1st order "alpha" filter. 

Convergence result on a simple python simulation:
![hover_thr_1_state](https://user-images.githubusercontent.com/14822839/66471569-d2d46780-ea8b-11e9-9b3f-26c7d50dc7c2.png)

**update**: added an adaptive law to adjust the noise measurement variance based on [Adaptive Adjustment of Noise Covariance in Kalman Filter for Dynamic State Estimation](https://arxiv.org/pdf/1702.00884.pdf), _S Akhlaghi_, ‎2017.
Tests on a sudden measurement noise increase (x5) 

- With a fixed measurement noise matrix:
![hover_thrust_estimator_ekf](https://user-images.githubusercontent.com/14822839/72678098-f784a600-3aa2-11ea-95de-864679db6951.png)

- With the adaptive law:
![hover_thrust_estimator_aekf](https://user-images.githubusercontent.com/14822839/72678102-fce1f080-3aa2-11ea-9520-71cd1611857f.png)

Note: the model of the filter assumes a constant state and is tested of a slow ramp; to achieve better tracking, we could use a first order Gauss-Markov model where the derivative of the state is noise driven instead of the state itself. We would have to see in practice if this is required or not.
TODO: use the normalized innovation test ratio to reject outliers. In case of multiple consecutive rejection, the state variance can be increased as this would be a sign of divergence of the filter or sudden change of hover thrust (e.g.:payload delivery).