### PR TITLE
Drag fusion tuning

### DIFF
--- a/drag_fusion_tuning/drag_fusion_symbolic.py
+++ b/drag_fusion_tuning/drag_fusion_symbolic.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+    Copyright (c) 2022 PX4 Development Team
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+    3. Neither the name PX4 nor the names of its contributors may be
+    used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+    OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+    AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+
+File: frag_fusion_symbolic.py
+Author: Mathieu Bresciani <mathieu@auterion.com>
+License: BSD 3-Clause
+Description:
+"""
+
+from sympy import *
+
+V = Symbol("V", real=True)
+rho = Symbol("rho", real=True)
+rho_n = Symbol("rho_n", real=True)
+Mcoef = Symbol("Mcoef", real=True)
+Bcoef = Symbol("Bcoef", real=True)
+a = Symbol("a", real=True)
+
+f1 = 0.5 * rho / Bcoef * V**2 + rho_n * Mcoef * V - a
+
+print("If Bcoef > 0 and Mcoef > 0")
+print("V =")
+res_V = solve(f1, V)
+res_V = res_V[0]
+pprint(res_V)
+print("a_pred =")
+pprint(solve(f1, a))

--- a/drag_fusion_tuning/drag_replay.py
+++ b/drag_fusion_tuning/drag_replay.py
@@ -139,21 +139,26 @@ def run(logfile):
     J = lambda x: np.sum(np.power(abs(a_body[0]-predict_acc_x(x)), 2.0) + np.power(abs(a_body[1]-predict_acc_y(x)), 2.0))
     x0 = [0.1, 10, 10]
     res = optimize.minimize(J, x0, method='nelder-mead', options={'disp': True})
-    print(f"BCoef_x = {res.x[1]}, BCoef_y = {res.x[2]}, MCoef = {res.x[0] / np.sqrt(rho / rho15)}")
 
     # Plot data
     plt.figure(1)
+    plt.suptitle(logfile.split('/')[-1])
     ax1 = plt.subplot(2, 1, 1)
     ax1.plot(t, v_body[0])
     ax1.plot(t, v_body[1])
-    ax1.legend(["v_forward", "v_right"])
+    ax1.set_xlabel("time (s)")
+    ax1.set_ylabel("velocity (m/s)")
+    ax1.legend(["forward", "right"])
 
     ax2 = plt.subplot(2, 1, 2, sharex=ax1)
+    ax2.set_title(f"BCoef_x = {res.x[1]:.1f}, BCoef_y = {res.x[2]:.1f}, MCoef = {res.x[0] / np.sqrt(rho / rho15):.4f}", loc="right")
     ax2.plot(t, a_body[0])
     ax2.plot(t, a_body[1])
     ax2.plot(t, predict_acc_x(res.x))
     ax2.plot(t, predict_acc_y(res.x))
-    ax2.legend(["a_forward", "a_right", "a_predicted"])
+    ax2.set_xlabel("time (s)")
+    ax2.set_ylabel("acceleration (m/s^2)")
+    ax2.legend(["meas_forward", "meas_right", "predicted_forward", "predicted_right"])
     plt.show()
 
 if __name__ == '__main__':

--- a/drag_fusion_tuning/drag_replay.py
+++ b/drag_fusion_tuning/drag_replay.py
@@ -1,0 +1,134 @@
+import matplotlib.pylab as plt
+from pyulog import ULog
+from pyulog.px4 import PX4ULog
+import numpy as np
+import quaternion
+from scipy import optimize
+
+def getAllData(logfile, instance=1):
+    log = ULog(logfile)
+
+    v_local = np.matrix([getData(log, 'vehicle_local_position', 'vx'),
+              getData(log, 'vehicle_local_position', 'vy'),
+              getData(log, 'vehicle_local_position', 'vz')])
+
+    t_v_local = ms2s(getData(log, 'vehicle_local_position', 'timestamp'))
+
+    accel = np.matrix([getData(log, 'sensor_combined', 'accelerometer_m_s2[0]'),
+              getData(log, 'sensor_combined', 'accelerometer_m_s2[1]'),
+              getData(log, 'sensor_combined', 'accelerometer_m_s2[2]')])
+    t_accel = ms2s(getData(log, 'sensor_combined', 'timestamp'))
+
+    q = np.matrix([getData(log, 'vehicle_attitude', 'q[0]'),
+              getData(log, 'vehicle_attitude', 'q[1]'),
+              getData(log, 'vehicle_attitude', 'q[2]'),
+              getData(log, 'vehicle_attitude', 'q[3]')])
+    t_q = ms2s(getData(log, 'vehicle_attitude', 'timestamp'))
+
+    dist_bottom = getData(log, 'vehicle_local_position', 'dist_bottom')
+    t_dist_bottom = ms2s(getData(log, 'vehicle_local_position', 'timestamp'))
+
+    (t_aligned, v_body_aligned, accel_aligned) = alignData(t_v_local, v_local, t_accel, accel, t_q, q, t_dist_bottom, dist_bottom)
+
+    t_aligned -= t_aligned[0]
+
+    return (t_aligned, v_body_aligned, accel_aligned)
+
+def alignData(t_v, v_local, t_accel, accel, t_q, q, t_dist_bottom, dist_bottom):
+    len_accel = len(t_accel)
+    len_q = len(t_q)
+    len_db = len(t_dist_bottom)
+    i_a = 0
+    i_q = 0
+    i_db = 0
+    v_body_aligned = np.empty((3,0))
+    accel_aligned = np.empty((3,0))
+    t_aligned = []
+
+    for i_v in range(len(t_v)):
+        t = t_v[i_v]
+        while t_accel[i_a] <= t and i_a < len_accel-1:
+            i_a += 1
+        while t_q[i_q] <= t and i_q < len_q-1:
+            i_q += 1
+        while t_dist_bottom[i_db] <= t and i_db < len_db-1:
+            i_db += 1
+
+        if dist_bottom[i_db] < 1.0:
+            continue
+
+        qk = np.quaternion(q[0, i_q],q[1, i_q],q[2, i_q],q[3, i_q])
+        q_vl = np.quaternion(0, v_local[0, i_v], v_local[1, i_v], v_local[2, i_v])
+        q_vb = qk.conjugate() * q_vl * qk # Get velocity in body frame
+        vb = quaternion.as_float_array(q_vb)[1:4]
+
+        v_body_aligned = np.append(v_body_aligned, [[vb[0]], [vb[1]], [vb[2]]], axis=1)
+        accel_aligned = np.append(accel_aligned, accel[:, i_a-1], axis=1)
+        t_aligned.append(t)
+
+    return (t_aligned, v_body_aligned, np.asarray(accel_aligned))
+
+def getData(log, topic_name, variable_name, instance=0):
+    variable_data = np.array([])
+    for elem in log.data_list:
+        if elem.name == topic_name:
+            if instance == elem.multi_id:
+                variable_data = elem.data[variable_name]
+                break
+
+    return variable_data
+
+def ms2s(time_ms):
+    return time_ms * 1e-6
+
+def run(logfile):
+    # TODO:
+    # - accumulate accel instead of smaple picking
+    # - use in air data only
+    (t, v_body, a_body) = getAllData(logfile)
+
+    rho = 1.15 # air densitiy
+    rho15 = 1.225 # air density at 15 degC
+
+    # Concatenate X and Y axes if the body is symmetric or if the bluff body drag is negligible (ballistic coefficient -> inf)
+    U = np.append(v_body[0], v_body[1])
+    Y = np.append(a_body[0], a_body[1])
+
+    # x[0]: momentum drag, scales with v
+    # x[1]: ballistic coefficient, scales with v^2
+    computed_output = lambda x: -U * x[0] - 0.5 * rho * U**2 * np.sign(U) / x[1]
+    J = lambda x: np.sum(np.power(abs(Y-computed_output(x)), 2.0))
+    x0 = [0.1, 10]
+    res = optimize.minimize(J, x0, method='nelder-mead', options={'disp': True})
+    print(f"BCoef = {res.x[1]}, MCoef = {res.x[0] / np.sqrt(rho / rho15)}")
+
+    # Plot data
+    plt.figure(1)
+    ax1 = plt.subplot(2, 1, 1)
+    ax1.plot(t, v_body[0])
+    ax1.plot(t, v_body[1])
+
+    ax2 = plt.subplot(2, 1, 2, sharex=ax1)
+    ax2.plot(t, a_body[0])
+    ax2.plot(t, a_body[1])
+    ax2.plot(np.append(t, t), computed_output(res.x))
+    plt.show()
+
+if __name__ == '__main__':
+    import os
+    import argparse
+
+    # Get the path of this script (without file name)
+    script_path = os.path.split(os.path.realpath(__file__))[0]
+
+    # Parse arguments
+    parser = argparse.ArgumentParser(
+        description='Estimate mag biases from ULog file')
+
+    # Provide parameter file path and name
+    parser.add_argument('logfile', help='Full ulog file path, name and extension', type=str)
+    args = parser.parse_args()
+
+    logfile = os.path.abspath(args.logfile) # Convert to absolute path
+
+    run(logfile)

--- a/drag_fusion_tuning/drag_replay.py
+++ b/drag_fusion_tuning/drag_replay.py
@@ -89,17 +89,17 @@ def alignData(t_v, v_local, t_accel, accel, t_q, q, t_dist_bottom, dist_bottom):
         t = t_v[i_v]
         accel_sum = np.zeros((3,1))
         accel_count = 0
-        while t_accel[i_a] <= t and i_a < len_accel-1:
+        while t_accel[i_a] < t and i_a < len_accel-1:
             accel_sum += accel[:, i_a] # Integrate accel samples between 2 velocity samples
             accel_count += 1
             i_a += 1
-        while t_q[i_q] <= t and i_q < len_q-1:
+        while t_q[i_q] < t and i_q < len_q-1:
             i_q += 1
-        while t_dist_bottom[i_db] <= t and i_db < len_db-1:
+        while t_dist_bottom[i_db] < t and i_db < len_db-1:
             i_db += 1
 
         # Only use in air data
-        if dist_bottom[i_db] < 1.0:
+        if dist_bottom[i_db] < 1.0 or accel_count == 0:
             continue
 
         qk = np.quaternion(q[0, i_q],q[1, i_q],q[2, i_q],q[3, i_q])

--- a/drag_fusion_tuning/drag_replay.py
+++ b/drag_fusion_tuning/drag_replay.py
@@ -47,7 +47,11 @@ def alignData(t_v, v_local, t_accel, accel, t_q, q, t_dist_bottom, dist_bottom):
 
     for i_v in range(len(t_v)):
         t = t_v[i_v]
+        accel_sum = np.zeros((3,1))
+        accel_count = 0
         while t_accel[i_a] <= t and i_a < len_accel-1:
+            accel_sum += accel[:, i_a] # Integrate accel samples between 2 velocity samples
+            accel_count += 1
             i_a += 1
         while t_q[i_q] <= t and i_q < len_q-1:
             i_q += 1
@@ -63,7 +67,7 @@ def alignData(t_v, v_local, t_accel, accel, t_q, q, t_dist_bottom, dist_bottom):
         vb = quaternion.as_float_array(q_vb)[1:4]
 
         v_body_aligned = np.append(v_body_aligned, [[vb[0]], [vb[1]], [vb[2]]], axis=1)
-        accel_aligned = np.append(accel_aligned, accel[:, i_a-1], axis=1)
+        accel_aligned = np.append(accel_aligned, accel_sum / accel_count, axis=1)
         t_aligned.append(t)
 
     return (t_aligned, v_body_aligned, np.asarray(accel_aligned))
@@ -82,9 +86,6 @@ def ms2s(time_ms):
     return time_ms * 1e-6
 
 def run(logfile):
-    # TODO:
-    # - accumulate accel instead of smaple picking
-    # - use in air data only
     (t, v_body, a_body) = getAllData(logfile)
 
     rho = 1.15 # air densitiy

--- a/drag_fusion_tuning/drag_replay.py
+++ b/drag_fusion_tuning/drag_replay.py
@@ -108,11 +108,13 @@ def run(logfile):
     ax1 = plt.subplot(2, 1, 1)
     ax1.plot(t, v_body[0])
     ax1.plot(t, v_body[1])
+    ax1.legend(["v_forward", "v_right"])
 
     ax2 = plt.subplot(2, 1, 2, sharex=ax1)
     ax2.plot(t, a_body[0])
     ax2.plot(t, a_body[1])
     ax2.plot(np.append(t, t), computed_output(res.x))
+    ax2.legend(["a_forward", "a_right", "a_predicted"])
     plt.show()
 
 if __name__ == '__main__':

--- a/drag_fusion_tuning/drag_replay.py
+++ b/drag_fusion_tuning/drag_replay.py
@@ -1,3 +1,43 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+    Copyright (c) 2022 PX4 Development Team
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+    3. Neither the name PX4 nor the names of its contributors may be
+    used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+    OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+    AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+
+File: drag_replay.py
+Author: Mathieu Bresciani <mathieu@auterion.com>
+License: BSD 3-Clause
+Description:
+    Find the best ballistic and momentum drag coefficients for wind estimation
+    using EKF2 replay data.
+    NOTE: this script currently assumes no wind.
+"""
+
 import matplotlib.pylab as plt
 from pyulog import ULog
 from pyulog.px4 import PX4ULog
@@ -58,6 +98,7 @@ def alignData(t_v, v_local, t_accel, accel, t_q, q, t_dist_bottom, dist_bottom):
         while t_dist_bottom[i_db] <= t and i_db < len_db-1:
             i_db += 1
 
+        # Only use in air data
         if dist_bottom[i_db] < 1.0:
             continue
 

--- a/drag_fusion_tuning/drag_replay.py
+++ b/drag_fusion_tuning/drag_replay.py
@@ -140,6 +140,24 @@ def run(logfile):
     x0 = [0.1, 10, 10]
     res = optimize.minimize(J, x0, method='nelder-mead', options={'disp': True})
 
+    innov_var = J(res.x) / (len(v_body[0]) + len(v_body[1]))
+    mcoef = res.x[0] / np.sqrt(rho / rho15)
+    bcoef_x = res.x[1]
+    bcoef_y = res.x[2]
+
+    if bcoef_x > 200:
+        print(f"BCOEF_X too large, disabling parameter")
+        bcoef_x = 0.0
+
+    if bcoef_y > 200:
+        print(f"BCOEF_Y too large, disabling parameter")
+        bcoef_y = 0.0
+
+    print(f"param set EKF2_BCOEF_X {bcoef_x:.1f}")
+    print(f"param set EKF2_BCOEF_Y {bcoef_y:.1f}")
+    print(f"param set EKF2_MCOEF {mcoef:.2f}")
+    print(f"/!\EXPERIMENTAL param set EKF2_DRAG_NOISE {innov_var:.2f}")
+
     # Plot data
     plt.figure(1)
     plt.suptitle(logfile.split('/')[-1])
@@ -151,7 +169,7 @@ def run(logfile):
     ax1.legend(["forward", "right"])
 
     ax2 = plt.subplot(2, 1, 2, sharex=ax1)
-    ax2.set_title(f"BCoef_x = {res.x[1]:.1f}, BCoef_y = {res.x[2]:.1f}, MCoef = {res.x[0] / np.sqrt(rho / rho15):.4f}", loc="right")
+    ax2.set_title(f"BCoef_x = {bcoef_x:.1f}, BCoef_y = {bcoef_y:.1f}, MCoef = {mcoef:.4f}", loc="right")
     ax2.plot(t, a_body[0])
     ax2.plot(t, a_body[1])
     ax2.plot(t, predict_acc_x(res.x))


### PR DESCRIPTION
WARNING: the current state of this script assumes no wind. Some modifications are required if we want to estimate the wind and the parameters at the same time.

Output of `drag_replay.py`:
```
param set EKF2_BCOEF_X 0.0
param set EKF2_BCOEF_Y 62.1
param set EKF2_MCOEF 0.16
/!\EXPERIMENTAL param set EKF2_DRAG_NOISE 0.31
```
![DeepinScreenshot_matplotlib_20220329100027](https://user-images.githubusercontent.com/14822839/160563024-efddd100-d7db-46f7-8676-cf4296e9f737.png)


(Note: BCoef_x is a really large number because the bluff body drag contribution is negligible for that vehicle -> 1/BCoef ~= 0)

Output of `drag_fusion_symbolic.py`
```
If Bcoef > 0 and Mcoef > 0
V =
                     ____________________________________
                    ╱       ⎛           2   2          ⎞ 
-Bcoef⋅Mcoef⋅ρₙ - ╲╱  Bcoef⋅⎝Bcoef⋅Mcoef ⋅ρₙ  + 2.0⋅a⋅ρ⎠ 
─────────────────────────────────────────────────────────
                            ρ                            
a_pred =
⎡                  2  ⎤
⎢             0.5⋅V ⋅ρ⎥
⎢Mcoef⋅V⋅ρₙ + ────────⎥
⎣              Bcoef  ⎦
```