### PR TITLE
Corrected errors in autotune

### DIFF
--- a/autotune/autotune.py
+++ b/autotune/autotune.py
@@ -451,8 +451,8 @@ class Window(QDialog):
     def plotPolesZeros(self):
         if not self.is_system_identified:
             return
-        poles = self.Gz.pole()
-        zeros = self.Gz.zero()
+        poles = self.Gz.poles()
+        zeros = self.Gz.zeros()
         if not self.pz_plot_refs:
             ax = self.figure.add_subplot(3,3,6)
             plot_ref = ax.plot(poles.real, poles.imag, 'rx', markersize=10)

--- a/autotune/readme.md
+++ b/autotune/readme.md
@@ -1,7 +1,7 @@
 # Installation using a virtual environment
 ## Create a new venv
 ```
-python3.9 -m venv virtualenv-test
+python3.10 -m venv virtualenv-test
 source virtualenv-test/bin/activate
 ```
 


### PR DESCRIPTION
Corrected minor variable naming errors in autotune file as well as updated the readme to use the latest python venv.

**Before:**
- misspelt variables
- python 3.9 venv

**Now:**
- corrected variable names
- python 3.10 venv