### PR TITLE
Add different PID structures

### DIFF
--- a/autotune/autotune.py
+++ b/autotune/autotune.py
@@ -37,7 +37,7 @@ Description:
 """
 
 import sys
-from PyQt5.QtWidgets import QDialog, QApplication, QLabel, QRadioButton, QSlider, QPushButton, QVBoxLayout, QHBoxLayout, QFormLayout, QFileDialog, QLineEdit, QSpinBox, QDoubleSpinBox, QMessageBox, QTableWidget, QTableWidgetItem, QHeaderView
+from PyQt5.QtWidgets import QDialog, QApplication, QLabel, QRadioButton, QSlider, QPushButton, QVBoxLayout, QHBoxLayout, QFormLayout, QFileDialog, QLineEdit, QSpinBox, QDoubleSpinBox, QMessageBox, QCheckBox, QTableWidget, QTableWidgetItem, QHeaderView
 from PyQt5.QtCore import Qt
 
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
@@ -270,7 +270,13 @@ class Window(QDialog):
     def createPidLayout(self):
         layout_pid = QFormLayout()
 
-        layout_pid.addRow(QLabel("Ideal/Standard: Kp * [1 + Ki + Kd]\t(Parallel: Kp + Ki + Kd)"))
+        layout_structure = QHBoxLayout()
+        layout_structure.addWidget(QLabel("Ideal/Standard: Kp * [1 + Ki + Kd]\t(Parallel: Kp + Ki + Kd)"))
+        self.pid_no_zero_box = QCheckBox("PI no-zero", self)
+        self.pid_no_zero_box.setChecked(False)
+        self.pid_no_zero_box.stateChanged.connect(self.updateClosedLoop)
+        layout_structure.addWidget(self.pid_no_zero_box)
+        layout_pid.addRow(layout_structure)
 
         layout_k = QHBoxLayout()
         self.slider_k = DoubleSlider(Qt.Horizontal)
@@ -586,7 +592,7 @@ class Window(QDialog):
         p_control = ctrl.TransferFunction([kc], [1], dt, inputs='id_out', outputs='pid_out')
         sum_control = ctrl.summing_junction(inputs=['pid_out', 'ff_out'], output='u')
 
-        remove_zero = False
+        remove_zero = self.pid_no_zero_box.isChecked()
         no_derivative_kick = True
 
         if remove_zero:

--- a/autotune/autotune.py
+++ b/autotune/autotune.py
@@ -59,6 +59,7 @@ class Window(QDialog):
 
         self._plot_ref = None
         self.closed_loop_ref = None
+        self.closed_loop_ax = None
         self.bode_plot_ref = None
         self.state_plot_refs= []
         self.pz_plot_refs= []
@@ -588,12 +589,14 @@ class Window(QDialog):
             ax.step(t, [1 if i>0 else 0 for i in t], 'k--')
             plot_ref = ax.plot(t, y)
             self.closed_loop_ref = plot_ref[0]
+            self.closed_loop_ax = ax
             ax.set_title("Closed-loop step response")
             ax.set_xlabel("Time (s)")
             ax.set_ylabel("Amplitude (rad/s)")
         else:
             self.closed_loop_ref.set_xdata(t)
             self.closed_loop_ref.set_ydata(y)
+            self.closed_loop_ax.set_ylim(np.min(y),np.max([1.5, np.max(y)]))
 
         self.canvas.draw()
 

--- a/autotune/data_selection_window.py
+++ b/autotune/data_selection_window.py
@@ -46,7 +46,7 @@ class DataSelectionWindow(QDialog):
 
     def loadLog(self):
         if self.t_stop > self.t_start:
-            (self.t, self.u, self.y) = getInputOutputData(self.file_name, self.axis, self.t_start, self.t_stop)
+            (self.t, self.u, self.y, self.v) = getInputOutputData(self.file_name, self.axis, self.t_start, self.t_stop)
             self.accept()
         else:
             self.printRangeError()
@@ -73,7 +73,7 @@ class DataSelectionWindow(QDialog):
     def refreshInputOutputData(self, axis=0):
         if self.file_name:
             self.axis = axis
-            (self.t, self.u, self.y) = getInputOutputData(self.file_name, axis)
+            (self.t, self.u, self.y, self.v) = getInputOutputData(self.file_name, axis)
             self.plotInputOutput(redraw=True)
 
     def plotInputOutput(self, redraw=False):

--- a/autotune/pid_design.py
+++ b/autotune/pid_design.py
@@ -109,9 +109,9 @@ def gainsToNumDen(kc, ki, kd, dt):
     kIp = dt * kI / 2
     kDp = kD / dt
 
-    b0 = kc + kIp + kDp
-    b1 = -kc + kIp - 2*kDp
-    b2 = kDp
+    b0 = kDp
+    b1 = kc + kIp - 2*kDp
+    b2 = -kc + kIp + kDp
 
     num = [b0, b1, b2]
     den = [1, -1, 0]


### PR DESCRIPTION
The 3 PID structures described below are now implemented.

In addition to this, for fixedwing vehicles, the true airspeed is used to scale (v_true^2/v_trim^2) the model inputs to linearize and identify a dynamic model "at trim airspeed" (can be defined in the GUI).
TODO: 
- [x] GUI to select structures at runtime
![Screenshot from 2025-05-05 15-01-39](https://github.com/user-attachments/assets/c195ca2b-cd80-4b5a-b8f5-ca3687fd1264)
