### PR TITLE
Autotune: add coherence plot for data selection

### DIFF
--- a/autotune/data_selection_window.py
+++ b/autotune/data_selection_window.py
@@ -225,6 +225,7 @@ class DataSelectionWindow(QDialog):
             self.ax_coherence.set_title("Coherence")
             self.ax_coherence.set_xlabel("Frequency (Hz)")
             self.ax_coherence.set_ylabel("Coherence")
+            self.ax_coherence.set_xscale('log')
 
             self.canvas.mpl_connect('scroll_event', self.zoom_fun)
             self.canvas.draw()
@@ -278,9 +279,13 @@ class DataSelectionWindow(QDialog):
             )   
 
         num_samples = len(t_sel)
+        duration = t_sel[-1] - t_sel[0]
         
-        if num_samples < 256:
-            self.label_warning.setText(f"Not enough data ({num_samples} samples). Select a larger window.")
+        if num_samples < 256 or duration < 5:
+            self.label_warning.setText(
+                f"Increase the window size to at least 5 seconds and 256 samples. "
+                f"Currently selected: {duration:.2f} seconds, {num_samples} samples."
+            )
             self.label_warning.show()
             
             self.coherence_ref.set_xdata([])
@@ -305,7 +310,7 @@ class DataSelectionWindow(QDialog):
         # Update coherence plot 
         self.coherence_ref.set_xdata(freq)
         self.coherence_ref.set_ydata(Cuy)
-        self.ax_coherence.set_xlim([min(freq), max(freq)])
+        self.ax_coherence.set_xlim([0, 20])
         self.ax_coherence.set_ylim([0, 1])
 
         # Remove previous annotation if it exists
@@ -313,7 +318,6 @@ class DataSelectionWindow(QDialog):
             self.coherence_info_text.remove()
             self.coherence_info_text = None
 
-        duration = t_sel[-1] - t_sel[0]
         freq_res = fs / nperseg
         info_text = (f"Samples: {num_samples}, Duration: {duration:.2f}s, "
                     f"fs: {fs:.1f}Hz, nperseg: {nperseg}, Δf: {freq_res:.2f}Hz")

--- a/autotune/data_selection_window.py
+++ b/autotune/data_selection_window.py
@@ -5,6 +5,7 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.widgets import SpanSelector
 
 import numpy as np
+from scipy import signal
 
 from data_extractor import DataExtractor
 from searchable_combo_box import SearchableComboBox
@@ -56,9 +57,9 @@ class DataSelectionWindow(QDialog):
 
         self.input_ref = None
         self.output_ref = None
-        self.figure = plt.figure(1)
+        self.figure = plt.figure(figsize=(8, 6))
         self.canvas = FigureCanvas(self.figure)
-        self.initPlot()
+        self.initPlots()
 
         layout_v = QVBoxLayout()
 
@@ -183,10 +184,12 @@ class DataSelectionWindow(QDialog):
     def getTrimAirspeed(self):
         return self.data_extractor.getTrimAirspeed()
 
-    def initPlot(self):
+    def initPlots(self):
         if self.input_ref is None:
             self.figure.clear()
-            self.ax = self.figure.add_subplot(1,1,1)
+
+            # --- Time series Axes (Top) --- 
+            self.ax = self.figure.add_subplot(2,1,1)
             color_in = 'tab:blue'
             plot_refs = self.ax.plot([], [], color=color_in)
             self.input_ref = plot_refs[0]
@@ -207,6 +210,15 @@ class DataSelectionWindow(QDialog):
 
             self.span = SpanSelector(self.ax_out, self.onselect, 'horizontal', useblit=False,
                                 props=dict(alpha=0.2, facecolor='green'), interactive=True)
+            
+            # --- Coherence Plot (Bottom) --- 
+            self.ax_coherence = self.figure.add_subplot(2, 1, 2)
+            self.ax_coherence.set_title("Coherence")
+            self.ax_coherence.set_xlabel("Frequency [Hz]")
+            self.ax_coherence.set_ylabel("Coherence")
+            self.coherence_ref, = self.ax_coherence.plot([], [])
+
+            self.figure.tight_layout()
 
             self.canvas.mpl_connect('scroll_event', self.zoom_fun)
             self.canvas.draw()
@@ -231,6 +243,71 @@ class DataSelectionWindow(QDialog):
             self.ax_out.set_ylim([min_y, max_y])
         self.canvas.draw()
 
+    def plotCoherence(self):
+        if len(self.t) == 0 or len(self.u) == 0 or len(self.y) == 0:
+            return
+
+        # Use selected range if available
+        if self.t_start is not None and self.t_stop is not None and self.t_stop > self.t_start:
+            # Get indices within selected range
+            ind_start = np.searchsorted(self.t, self.t_start)
+            ind_stop = np.searchsorted(self.t, self.t_stop)
+
+            t_sel = self.t[ind_start:ind_stop]
+            u_sel = self.u[ind_start:ind_stop]
+            y_sel = self.y[ind_start:ind_stop]
+        else:
+            # Fall back to full signal if no range selected
+            t_sel = self.t
+            u_sel = self.u
+            y_sel = self.y
+
+        num_samples = len(t_sel)
+        if num_samples < 64: # I kind of made up this number -> maybe requires some research 
+            self.ax_coherence.clear()
+            self.ax_coherence.set_title("Coherence (Selection too short)")
+            self.ax_coherence.text(0.5, 0.5, f"Not enough data ({num_samples} samples).\nSelect a larger window.",
+                                ha='center', va='center', transform=self.ax_coherence.transAxes,
+                                fontsize=10, color='red')
+            self.canvas.draw()
+            return
+
+        # Estimate sampling frequency
+        time_diffs = np.diff(t_sel)
+        avg_time_diff = np.mean(time_diffs)
+        if avg_time_diff == 0:
+            return 
+        fs = 1 / avg_time_diff
+
+        # Choose segment size
+        nperseg = min(256, num_samples // 4) # Also needs to be verified 
+
+        # Compute coherence
+        freq, Cuy = signal.coherence(u_sel, y_sel, fs, nperseg=nperseg)
+
+        # Update coherence plot
+        self.ax_coherence.clear()
+        self.ax_coherence.plot(freq, Cuy, label='Coherence(u, y)')
+        self.ax_coherence.set_title("Coherence")
+        self.ax_coherence.set_xlabel("Frequency [Hz]")
+        self.ax_coherence.set_ylabel("Coherence")
+        self.ax_coherence.set_xlim([min(freq), max(freq)])
+        self.ax_coherence.set_ylim([0, 1])
+        self.ax_coherence.grid(True)
+
+        # Add informative annotation
+        duration = t_sel[-1] - t_sel[0]
+        freq_res = fs / nperseg
+        info_text = (f"Samples: {num_samples}, Duration: {duration:.2f}s, "
+                    f"fs: {fs:.1f}Hz, nperseg: {nperseg}, Δf: {freq_res:.2f}Hz")
+
+        self.ax_coherence.text(0.98, 0.02, info_text,
+                            ha='right', va='bottom',
+                            transform=self.ax_coherence.transAxes,
+                            fontsize=8, color='gray')
+
+        self.canvas.draw()
+
     def onselect(self, xmin, xmax):
         indmin, indmax = np.searchsorted(self.t, (xmin, xmax))
         indmax = min(len(self.t) - 1, indmax)
@@ -240,6 +317,8 @@ class DataSelectionWindow(QDialog):
         self.t_stop = self.t[indmax]
         self.ax.set_xlim(self.t_start - 1.0, self.t_stop + 1.0)
         self.canvas.draw()
+
+        self.plotCoherence()
 
     def zoom_fun(self, event):
         base_scale = 1.1

--- a/autotune/data_selection_window.py
+++ b/autotune/data_selection_window.py
@@ -57,7 +57,9 @@ class DataSelectionWindow(QDialog):
 
         self.input_ref = None
         self.output_ref = None
-        self.figure = plt.figure(figsize=(8, 6))
+        self.coherence_ref = None 
+        self.coherence_info_text = None
+        self.figure = plt.figure(figsize=(8, 6), layout="constrained")
         self.canvas = FigureCanvas(self.figure)
         self.initPlots()
 
@@ -87,6 +89,10 @@ class DataSelectionWindow(QDialog):
         layout_v.addLayout(top_group)
         layout_v.addWidget(self.canvas)
 
+        self.label_warning = QLabel("")
+        self.label_warning.setStyleSheet("color: red; font-weight: bold;")
+        layout_v.addWidget(self.label_warning)
+
         btn_ok = QPushButton("Load selection")
         btn_ok.clicked.connect(self.loadSelection)
         layout_v.addWidget(btn_ok)
@@ -101,7 +107,7 @@ class DataSelectionWindow(QDialog):
             self.browseFiles()
 
     def loadSelection(self):
-        if (self.t_start is None and self.t_start is None) or (self.t_stop > self.t_start):
+        if (self.t_start is None and self.t_stop is None) or (self.t_stop > self.t_start):
             (self.t, self.u, self.y, self.v) = self.data_extractor.getInputOutputData(self.topics[self.index_u], self.topics[self.index_y], self.t_start, self.t_stop)
             self.accept()
         else:
@@ -213,12 +219,12 @@ class DataSelectionWindow(QDialog):
             
             # --- Coherence Plot (Bottom) --- 
             self.ax_coherence = self.figure.add_subplot(2, 1, 2)
+            color_coherence = 'tab:grey'
+            plot_refs = self.ax_coherence.plot([], [], color=color_coherence)
+            self.coherence_ref = plot_refs[0]
             self.ax_coherence.set_title("Coherence")
-            self.ax_coherence.set_xlabel("Frequency [Hz]")
+            self.ax_coherence.set_xlabel("Frequency (Hz)")
             self.ax_coherence.set_ylabel("Coherence")
-            self.coherence_ref, = self.ax_coherence.plot([], [])
-
-            self.figure.tight_layout()
 
             self.canvas.mpl_connect('scroll_event', self.zoom_fun)
             self.canvas.draw()
@@ -243,10 +249,22 @@ class DataSelectionWindow(QDialog):
             self.ax_out.set_ylim([min_y, max_y])
         self.canvas.draw()
 
+    def onselect(self, xmin, xmax):
+        indmin, indmax = np.searchsorted(self.t, (xmin, xmax))
+        indmax = min(len(self.t) - 1, indmax)
+        indmin = min(indmin, indmax)
+
+        self.t_start = self.t[indmin]
+        self.t_stop = self.t[indmax]
+        self.ax.set_xlim(self.t_start - 1.0, self.t_stop + 1.0)
+        self.canvas.draw()
+
+        self.plotCoherence()
+
     def plotCoherence(self):
         if len(self.t) == 0 or len(self.u) == 0 or len(self.y) == 0:
             return
-
+    
         # Use getInputOutputData with selected range
         if self.t_start is not None and self.t_stop is not None and self.t_stop > self.t_start:
             t_sel, u_sel, y_sel, _ = self.data_extractor.getInputOutputData(
@@ -260,14 +278,16 @@ class DataSelectionWindow(QDialog):
             )   
 
         num_samples = len(t_sel)
-        if num_samples < 256: # I kind of made up this number -> maybe requires some research 
-            self.ax_coherence.clear()
-            self.ax_coherence.set_title("Coherence (Selection too short)")
-            self.ax_coherence.text(0.5, 0.5, f"Not enough data ({num_samples} samples).\nSelect a larger window.",
-                                ha='center', va='center', transform=self.ax_coherence.transAxes,
-                                fontsize=10, color='red')
-            self.canvas.draw()
-            return
+        
+        if num_samples < 256:
+            self.label_warning.setText(f"Not enough data ({num_samples} samples). Select a larger window.")
+            self.label_warning.show()
+            
+            self.coherence_ref.set_xdata([])
+            self.coherence_ref.set_ydata([])
+            return      
+        else:
+            self.label_warning.hide()
 
         # Estimate sampling frequency
         time_diffs = np.diff(t_sel)
@@ -277,45 +297,35 @@ class DataSelectionWindow(QDialog):
         fs = 1 / avg_time_diff
 
         # Choose segment size
-        nperseg = min(1024, max(256, num_samples // 8))
+        nperseg = min(1024, num_samples // 4)
 
         # Compute coherence
         freq, Cuy = signal.coherence(u_sel, y_sel, fs, nperseg=nperseg)
 
-        # Update coherence plot
-        self.ax_coherence.clear()
-        self.ax_coherence.plot(freq, Cuy, label='Coherence(u, y)')
-        self.ax_coherence.set_title("Coherence")
-        self.ax_coherence.set_xlabel("Frequency [Hz]")
-        self.ax_coherence.set_ylabel("Coherence")
+        # Update coherence plot 
+        self.coherence_ref.set_xdata(freq)
+        self.coherence_ref.set_ydata(Cuy)
         self.ax_coherence.set_xlim([min(freq), max(freq)])
         self.ax_coherence.set_ylim([0, 1])
-        self.ax_coherence.grid(True)
 
-        # Add informative annotation
+        # Remove previous annotation if it exists
+        if self.coherence_info_text is not None:
+            self.coherence_info_text.remove()
+            self.coherence_info_text = None
+
         duration = t_sel[-1] - t_sel[0]
         freq_res = fs / nperseg
         info_text = (f"Samples: {num_samples}, Duration: {duration:.2f}s, "
                     f"fs: {fs:.1f}Hz, nperseg: {nperseg}, Δf: {freq_res:.2f}Hz")
-
-        self.ax_coherence.text(0.98, 0.02, info_text,
-                            ha='right', va='bottom',
-                            transform=self.ax_coherence.transAxes,
-                            fontsize=8, color='gray')
+        
+        self.coherence_info_text = self.ax_coherence.text(
+            0.98, 0.02, info_text,
+            ha='right', va='bottom',
+            transform=self.ax_coherence.transAxes,
+            fontsize=8, color='gray')
 
         self.canvas.draw()
 
-    def onselect(self, xmin, xmax):
-        indmin, indmax = np.searchsorted(self.t, (xmin, xmax))
-        indmax = min(len(self.t) - 1, indmax)
-        indmin = min(indmin, indmax)
-
-        self.t_start = self.t[indmin]
-        self.t_stop = self.t[indmax]
-        self.ax.set_xlim(self.t_start - 1.0, self.t_stop + 1.0)
-        self.canvas.draw()
-
-        self.plotCoherence()
 
     def zoom_fun(self, event):
         base_scale = 1.1

--- a/autotune/data_selection_window.py
+++ b/autotune/data_selection_window.py
@@ -247,23 +247,20 @@ class DataSelectionWindow(QDialog):
         if len(self.t) == 0 or len(self.u) == 0 or len(self.y) == 0:
             return
 
-        # Use selected range if available
+        # Use getInputOutputData with selected range
         if self.t_start is not None and self.t_stop is not None and self.t_stop > self.t_start:
-            # Get indices within selected range
-            ind_start = np.searchsorted(self.t, self.t_start)
-            ind_stop = np.searchsorted(self.t, self.t_stop)
-
-            t_sel = self.t[ind_start:ind_stop]
-            u_sel = self.u[ind_start:ind_stop]
-            y_sel = self.y[ind_start:ind_stop]
+            t_sel, u_sel, y_sel, _ = self.data_extractor.getInputOutputData(
+                self.topics[self.index_u], self.topics[self.index_y],
+                self.t_start, self.t_stop
+            )
         else:
-            # Fall back to full signal if no range selected
-            t_sel = self.t
-            u_sel = self.u
-            y_sel = self.y
+            # If no range selected, just use full duration
+            t_sel, u_sel, y_sel, _ = self.data_extractor.getInputOutputData(
+                self.topics[self.index_u], self.topics[self.index_y]
+            )   
 
         num_samples = len(t_sel)
-        if num_samples < 64: # I kind of made up this number -> maybe requires some research 
+        if num_samples < 256: # I kind of made up this number -> maybe requires some research 
             self.ax_coherence.clear()
             self.ax_coherence.set_title("Coherence (Selection too short)")
             self.ax_coherence.text(0.5, 0.5, f"Not enough data ({num_samples} samples).\nSelect a larger window.",
@@ -280,7 +277,7 @@ class DataSelectionWindow(QDialog):
         fs = 1 / avg_time_diff
 
         # Choose segment size
-        nperseg = min(256, num_samples // 4) # Also needs to be verified 
+        nperseg = min(1024, max(256, num_samples // 8))
 
         # Compute coherence
         freq, Cuy = signal.coherence(u_sel, y_sel, fs, nperseg=nperseg)


### PR DESCRIPTION
(For now I left everything as one function, but not sure if it might be cleaner to split up the computing and plotting?)


Plot the coherence of the selected window: 

1. 
<img width="415" height="395" alt="image" src="https://github.com/user-attachments/assets/9ef88ee7-5aae-4eb9-be1c-d5dde00ddae4" />

Also gives additional information of the window: # of samples, duration, sampling frequency, # of samples per segments (used in Welch's method), and the frequency resolution. 

2. If the selected window is too small to compute a meaningful coherence, the data is cleared and a  "Not enough data" label is displayed: 

<img width="415" height="395" alt="image" src="https://github.com/user-attachments/assets/de7d1040-7fdb-4870-8ff2-8d467809084f" />

