### PR TITLE
fix(autotune): flatten u/y arrays in apply_filters to fix ValueError

### DIFF
--- a/autotune/system_identification.py
+++ b/autotune/system_identification.py
@@ -45,6 +45,8 @@ from scipy.optimize import lsq_linear
 
 
 def apply_filters(u, y, f_hp, f_lp, dt):
+    u = np.asarray(u).ravel()
+    y = np.asarray(y).ravel()
     n_steps = len(u)
 
     if f_hp > 0.0:


### PR DESCRIPTION
u and y were passed as 2D column vectors (shape (n,1)) from autotune.py, causing "setting an array element with a sequence" when initializing the 1D filter output arrays. Added np.ravel() at the start of apply_filters to normalize inputs to 1D.